### PR TITLE
Helm: provide a way to expose services through ingress-controller

### DIFF
--- a/infrastructure/helm/quantumserverless/Chart.lock
+++ b/infrastructure/helm/quantumserverless/Chart.lock
@@ -2,6 +2,9 @@ dependencies:
 - name: jupyter
   repository: ""
   version: 0.1.0
+- name: nginx-ingress-controller
+  repository: https://charts.bitnami.com/bitnami
+  version: 9.3.26
 - name: kuberay-operator
   repository: https://ray-project.github.io/kuberay-helm
   version: 0.4.0
@@ -14,5 +17,5 @@ dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 17.4.3
-digest: sha256:1f1f3a40ece0093c3f1fa0fa6fe4e1cb43b8268ac2411701dc3bf0e95a0f0e02
-generated: "2023-01-18T14:35:23.24738369Z"
+digest: sha256:6a12f46e80b855dbbd40f5c70a3fea9626f7fce6d7485ad70e078b7983239d8f
+generated: "2023-01-20T14:57:45.991889+01:00"

--- a/infrastructure/helm/quantumserverless/Chart.yaml
+++ b/infrastructure/helm/quantumserverless/Chart.yaml
@@ -11,6 +11,10 @@ dependencies:
   - name: jupyter
     condition: jupyterEnable
     version: 0.1.0
+  - name: nginx-ingress-controller
+    condition:
+    version: 9.3.26
+    repository: https://charts.bitnami.com/bitnami
   - name: kuberay-operator
     condition: kuberayOperatorEnable
     version: 0.4.0

--- a/infrastructure/helm/quantumserverless/Chart.yaml
+++ b/infrastructure/helm/quantumserverless/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
     condition: jupyterEnable
     version: 0.1.0
   - name: nginx-ingress-controller
-    condition:
+    condition: nginxIngressControllerEnable
     version: 9.3.26
     repository: https://charts.bitnami.com/bitnami
   - name: kuberay-operator

--- a/infrastructure/helm/quantumserverless/README.md
+++ b/infrastructure/helm/quantumserverless/README.md
@@ -23,9 +23,12 @@ The Quantum Serverless Chart has several internal and external dependencies. If 
 
 ## Helm chart values
 
-**Redis**
+**Redis & Nginx Ingress controller**
 
-For our Redis dependency we are using the configuration created by Bitnami. To simplify the configuration we offered you with a straigh-forward initial parameters setup. But if you are interested in more complex configurations you have access to all the parameters that Bitnami added in the chart specified in their [README](https://artifacthub.io/packages/helm/bitnami/redis).
+For our Redis and Nginx Ingress controller dependencies we are using the configuration created by Bitnami. To simplify the configuration we offered you with a straigh-forward initial parameters setup. 
+But if you are interested in more complex configurations you have access to all the parameters that Bitnami added in the chart specified in their READMEs:
+* [Redis README](https://artifacthub.io/packages/helm/bitnami/redis).
+* [Nginx Ingress controller's README](https://artifacthub.io/packages/helm/bitnami/nginx-ingress-controller)
 
 **Jupyter notebook**
 

--- a/infrastructure/helm/quantumserverless/values.yaml
+++ b/infrastructure/helm/quantumserverless/values.yaml
@@ -46,6 +46,17 @@ jupyter:
 
   ingress:
     enabled: false
+    className: "nginx"
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    loadBalancer:
+      hostname: localhost
+    hosts:
+      - host: localhost
+        paths:
+          - path: /
+            pathType: Prefix
 
 
 # ===================

--- a/infrastructure/helm/quantumserverless/values.yaml
+++ b/infrastructure/helm/quantumserverless/values.yaml
@@ -3,6 +3,13 @@
 # ===================
 
 # ===================
+# Ingress Nginx controller configs
+# ===================
+
+# Ingress Nginx controller is disabled by default to not affect cloud providers' controller configuration
+nginxIngressControllerEnable: false
+
+# ===================
 # Redis configs
 # ===================
 
@@ -44,6 +51,7 @@ jupyter:
   service:
     port: 80
 
+  # If you enable it remember to enable nginx ingress controller if you need a controller for ingress
   ingress:
     enabled: false
     className: "nginx"

--- a/infrastructure/terraform/aws/values.yaml
+++ b/infrastructure/terraform/aws/values.yaml
@@ -2,6 +2,32 @@
 # Quantum Serverless configs
 # ===================
 
+# ===================
+# Ingress Nginx controller configs
+# ===================
+
+# Ingress Nginx controller is disabled by default to not affect cloud providers' controller configuration
+nginxIngressControllerEnable: false
+
+# ===================
+# Redis configs
+# ===================
+
+redisEnable: true
+redis:
+  architecture: "standalone"
+
+  global:
+    redis:
+      password: ""
+
+  auth:
+    enabled: false
+
+  master:
+    service:
+      ports:
+        redis: 7000
 
 # ===================
 # Jupyter configs
@@ -25,8 +51,20 @@ jupyter:
   service:
     port: 80
 
+  # If you enable it remember to enable nginx ingress controller if you need a controller for ingress
   ingress:
     enabled: false
+    className: "nginx"
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    loadBalancer:
+      hostname: localhost
+    hosts:
+      - host: localhost
+        paths:
+          - path: /
+            pathType: Prefix
 
 
 # ===================
@@ -44,7 +82,7 @@ manager:
   imagePullSecrets: []
 
   container:
-    port: 80
+    port: 5000
 
   service:
     port: 5000
@@ -54,63 +92,44 @@ manager:
 
 
 # ===================
-# Ray configs
+# Ray Cluster
 # ===================
 
-# RAY CLUSTER
-
 rayClusterEnable: true
-
 ray-cluster:
+  nameOverride: "kuberay"
+  fullnameOverride: ""
+
   image:
     repository: "<RAY_CLUSTER_IMAGE>"
     tag: "latest"
     pullPolicy: IfNotPresent
 
-  imagePullSecrets: []
-    # - name: an-existing-secret
-
-  nameOverride: "kuberay"
-  fullnameOverride: ""
-
   head:
-    initArgs:
+    rayStartParams:
       dashboard-host: '0.0.0.0'
-      port: '6379'
 
   worker:
     # If you want to disable the default workergroup
     # uncomment the line below
     # disabled: true
     replicas: 1
-    ports:
-      - containerPort: 80
-        protocol: TCP
-    resources:
-      limits:
-        cpu: 1
-      requests:
-        cpu: 200m
-
-  headServiceSuffix: "ray-operator.svc"
+    type: worker
 
   service:
-    type: LoadBalancer
-    port: 8080
+    type: ClusterIP
 
-# KUBERAY OPERATOR
 
-rayOperatorEnable: true
+# ===================
+# Kuberay Operator
+# ===================
 
-operator:
-  image:
-    repository: kuberay/operator
-    tag: nightly
-    pullPolicy: IfNotPresent
-
+kuberayOperatorEnable: true
+kuberay-operator:
   nameOverride: "kuberay-operator"
   fullnameOverride: "kuberay-operator"
 
+  rbacEnable: true
   ## Install Default RBAC roles and bindings
   rbac:
     create: true
@@ -127,9 +146,6 @@ operator:
     type: ClusterIP
     port: 8080
 
-  ingress:
-    enabled: false
-
   livenessProbe:
     initialDelaySeconds: 10
     periodSeconds: 5
@@ -141,4 +157,6 @@ operator:
     failureThreshold: 5
 
   createCustomResource: true
-  rbacEnable: true
+
+  batchScheduler:
+    enabled: false

--- a/infrastructure/terraform/ibm/values.yaml
+++ b/infrastructure/terraform/ibm/values.yaml
@@ -2,6 +2,32 @@
 # Quantum Serverless configs
 # ===================
 
+# ===================
+# Ingress Nginx controller configs
+# ===================
+
+# Ingress Nginx controller is disabled by default to not affect cloud providers' controller configuration
+nginxIngressControllerEnable: false
+
+# ===================
+# Redis configs
+# ===================
+
+redisEnable: true
+redis:
+  architecture: "standalone"
+
+  global:
+    redis:
+      password: ""
+
+  auth:
+    enabled: false
+
+  master:
+    service:
+      ports:
+        redis: 7000
 
 # ===================
 # Jupyter configs
@@ -25,8 +51,20 @@ jupyter:
   service:
     port: 80
 
+  # If you enable it remember to enable nginx ingress controller if you need a controller for ingress
   ingress:
     enabled: false
+    className: "nginx"
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    loadBalancer:
+      hostname: localhost
+    hosts:
+      - host: localhost
+        paths:
+          - path: /
+            pathType: Prefix
 
 
 # ===================
@@ -44,7 +82,7 @@ manager:
   imagePullSecrets: []
 
   container:
-    port: 80
+    port: 5000
 
   service:
     port: 5000
@@ -54,63 +92,44 @@ manager:
 
 
 # ===================
-# Ray configs
+# Ray Cluster
 # ===================
 
-# RAY CLUSTER
-
 rayClusterEnable: true
-
 ray-cluster:
+  nameOverride: "kuberay"
+  fullnameOverride: ""
+
   image:
     repository: "<RAY_CLUSTER_IMAGE>"
     tag: "latest"
     pullPolicy: IfNotPresent
 
-  imagePullSecrets: []
-    # - name: an-existing-secret
-
-  nameOverride: "kuberay"
-  fullnameOverride: ""
-
   head:
-    initArgs:
+    rayStartParams:
       dashboard-host: '0.0.0.0'
-      port: '6379'
 
   worker:
     # If you want to disable the default workergroup
     # uncomment the line below
     # disabled: true
     replicas: 1
-    ports:
-      - containerPort: 80
-        protocol: TCP
-    resources:
-      limits:
-        cpu: 1
-      requests:
-        cpu: 200m
-
-  headServiceSuffix: "ray-operator.svc"
+    type: worker
 
   service:
-    type: LoadBalancer
-    port: 8080
+    type: ClusterIP
 
-# KUBERAY OPERATOR
 
-rayOperatorEnable: true
+# ===================
+# Kuberay Operator
+# ===================
 
-operator:
-  image:
-    repository: kuberay/operator
-    tag: nightly
-    pullPolicy: IfNotPresent
-
+kuberayOperatorEnable: true
+kuberay-operator:
   nameOverride: "kuberay-operator"
   fullnameOverride: "kuberay-operator"
 
+  rbacEnable: true
   ## Install Default RBAC roles and bindings
   rbac:
     create: true
@@ -127,9 +146,6 @@ operator:
     type: ClusterIP
     port: 8080
 
-  ingress:
-    enabled: false
-
   livenessProbe:
     initialDelaySeconds: 10
     periodSeconds: 5
@@ -141,4 +157,6 @@ operator:
     failureThreshold: 5
 
   createCustomResource: true
-  rbacEnable: true
+
+  batchScheduler:
+    enabled: false


### PR DESCRIPTION
### Summary

The main objective of this PR is to offer to the user an ingress-controller configuration in case it needs one to expose services. This is interesting for when you don't have an `ingress-controller` available in localhost when you develop, for example.

### Details and comments

- The ingress-controller is disabled by default to not affect cloud providers' controller default configuration.
- **Fix** `value.yaml` files in terraform with the last configurations.

Related with #125 