### PR TITLE
Add keycloak for Authorization with default configuration

### DIFF
--- a/infrastructure/helm/quantumserverless/Chart.lock
+++ b/infrastructure/helm/quantumserverless/Chart.lock
@@ -20,5 +20,8 @@ dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 17.6.0
-digest: sha256:6e21bbdd88ce78519c74b5b59400b2b3d82ed17c1697a7fd89dfbe516b746c10
-generated: "2023-01-25T10:17:37.619302165-05:00"
+- name: keycloak
+  repository: https://charts.bitnami.com/bitnami
+  version: 13.0.2
+digest: sha256:640aea437ec5a2d50f60b7589978e6fc410f68662c260fb8a8fa8d96cb253236
+generated: "2023-01-30T09:35:27.460425-05:00"

--- a/infrastructure/helm/quantumserverless/Chart.yaml
+++ b/infrastructure/helm/quantumserverless/Chart.yaml
@@ -34,3 +34,7 @@ dependencies:
     condition: redisEnable
     version: 17.6.0
     repository: https://charts.bitnami.com/bitnami
+  - name: keycloak
+    condition: keycloakEnable
+    version: 13.0.2
+    repository: https://charts.bitnami.com/bitnami

--- a/infrastructure/helm/quantumserverless/README.md
+++ b/infrastructure/helm/quantumserverless/README.md
@@ -35,6 +35,10 @@ But if you are interested in more complex configurations you have access to all 
 * [Redis README](https://artifacthub.io/packages/helm/bitnami/redis).
 * [Nginx Ingress controller's README](https://artifacthub.io/packages/helm/bitnami/nginx-ingress-controller)
 
+For our keycloak dependencies we are using the configuration created by Bitnami. To simplify the configuration we offered you with a straigh-forward initial parameters setup. 
+But if you are interested in more complex configurations you have access to all the parameters that Bitnami added in the chart specified in their READMEs:
+* [keycloak README](https://artifacthub.io/packages/helm/bitnami/keycloak)
+
 **Jupyter notebook**
 
 | Name                      | Description                                                       |

--- a/infrastructure/helm/quantumserverless/values.yaml
+++ b/infrastructure/helm/quantumserverless/values.yaml
@@ -214,4 +214,9 @@ kuberay-apiserver:
 
   replicaCount: 1
 
+# ===================
+# Keycloak 
+# ===================
+
+keycloakEnable: true
 

--- a/infrastructure/readme.md
+++ b/infrastructure/readme.md
@@ -34,7 +34,7 @@ In [this folder](./helm) you will find the main configuration to set up your k8s
 - **Operator**: a standard ray configuration to set up the KubeRay operator in the k8s cluster. This resource provides a Kubernetes-native way to manage Ray clusters.
 - **Ray cluster**: standard configuration to set up and deploy your Ray cluster in a k8s environment.
 - **Kuberay API server**: a standard configuration to manage KubeRay resources using gRPC and HTTP APIs.
-
+- **Keycloak**: a standard configuration to manage access to the resources
 
 ## Terraform
 The [folder](./terraform) contains the configuration that helps you to create your k8s and Ray clusters. Currently, the project supports deployments in:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR fix https://github.com/Qiskit-Extensions/quantum-serverless/issues/136
Adding keycloak dependency in the quantumserverless helm chart for preparation of authorization implementation.  

### Details and comments

Keycloak is installed with quantumserverless helm install.  It has still the default configuration.  The configuration will be updated when the OIDC proxy is put into the ray head node.
  
