### PR TITLE
Terraform: fix helm execution & update documentation

### DIFF
--- a/infrastructure/terraform/aws/main.tf
+++ b/infrastructure/terraform/aws/main.tf
@@ -41,8 +41,8 @@ resource "aws_vpc" "quantum_serverless_vpc" {
   cidr_block = "10.0.0.0/16"
 }
 
-resource "helm_release" "quantum_serverless_chart" {
-  name       = "quantum-serverless-chart"
+resource "helm_release" "quantum_serverless_release" {
+  name       = "quantum-serverless-release"
   chart      = "../../helm/quantumserverless"
 
   values = [

--- a/infrastructure/terraform/aws/readme.md
+++ b/infrastructure/terraform/aws/readme.md
@@ -5,22 +5,22 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.72 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.4.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.76.1 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.8.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.29.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.6.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.76.1 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.8.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_eks_blueprints"></a> [eks\_blueprints](#module\_eks\_blueprints) | github.com/aws-ia/terraform-aws-eks-blueprints | v4.8.0 |
+| <a name="module_eks_blueprints"></a> [eks\_blueprints](#module\_eks\_blueprints) | github.com/aws-ia/terraform-aws-eks-blueprints | v4.22.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 
 ## Resources
@@ -28,7 +28,7 @@
 | Name | Type |
 |------|------|
 | [aws_vpc.quantum_serverless_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
-| [helm_release.quantum_serverless_chart](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.quantum_serverless_release](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_eks_cluster_auth.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
 

--- a/infrastructure/terraform/aws/values.yaml
+++ b/infrastructure/terraform/aws/values.yaml
@@ -101,7 +101,7 @@ ray-cluster:
   fullnameOverride: ""
 
   image:
-    repository: "<RAY_CLUSTER_IMAGE>"
+    repository: "qiskit/quantum-serverless-ray-node"
     tag: "latest"
     pullPolicy: IfNotPresent
 

--- a/infrastructure/terraform/aws/values.yaml
+++ b/infrastructure/terraform/aws/values.yaml
@@ -160,3 +160,63 @@ kuberay-operator:
 
   batchScheduler:
     enabled: false
+
+# ===================
+# Kuberay API Server
+# ===================
+
+kuberayApiServerEnable: true
+kuberay-apiserver:
+  name: "kuberay-apiserver"
+  image:
+    repository: kuberay/apiserver
+    tag: v0.4.0
+    pullPolicy: IfNotPresent
+
+  rbacEnable: true
+  ## Install Default RBAC roles and bindings
+  rbac:
+    create: true
+    apiVersion: v1
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: "kuberay-apiserver"
+
+  containerPort:
+    - containerPort: 8888
+    - containerPort: 8887
+
+  resources:
+    limits:
+      cpu: 500m
+      memory: 500Mi
+    requests:
+      cpu: 300m
+      memory: 300Mi
+
+  service:
+    type: NodePort
+    ports:
+      - name: http
+        port: 8888
+        targetPort: 8888
+        nodePort: 31888
+      - name: rpc
+        port: 8887
+        targetPort: 8887
+        nodePort: 31887
+
+  ingress:
+    enabled: false
+
+  replicaCount: 1
+
+# ===================
+# Keycloak
+# ===================
+
+keycloakEnable: false

--- a/infrastructure/terraform/ibm/README.md
+++ b/infrastructure/terraform/ibm/README.md
@@ -5,15 +5,15 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.2 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.6.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.46.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.8.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.50.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.7.1 |
-| <a name="provider_ibm"></a> [ibm](#provider\_ibm) | 1.46.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.8.0 |
+| <a name="provider_ibm"></a> [ibm](#provider\_ibm) | 1.50.0 |
 
 ## Modules
 
@@ -26,7 +26,8 @@
 
 | Name | Type |
 |------|------|
-| [helm_release.quantum_severless_helm](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.quantum_serverless_release](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [ibm_container_cluster_config.quantum_serverless_cluster_config](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/container_cluster_config) | data source |
 | [ibm_resource_group.ibmcloud_resource_group](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs
@@ -50,3 +51,4 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | ID of the IKS on VPC Cluster |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The ID of the vpc |

--- a/infrastructure/terraform/ibm/helm.tf
+++ b/infrastructure/terraform/ibm/helm.tf
@@ -2,8 +2,8 @@
 # Create a helm execution
 ##############################################################################
 
-resource "helm_release" "quantum_serverless_chart" {
-  name       = "quantum-serverless-chart"
+resource "helm_release" "quantum_serverless_release" {
+  name       = "quantum-serverless-release"
   chart      = "../../helm/quantumserverless"
 
   values = [

--- a/infrastructure/terraform/ibm/helm.tf
+++ b/infrastructure/terraform/ibm/helm.tf
@@ -2,15 +2,17 @@
 # Create a helm execution
 ##############################################################################
 
-resource helm_release quantum_severless_helm {
-  depends_on = [
-    ibm_container_vpc_cluster.cluster
-  ]
-  name       = "${var.helm_name}"
-  chart      = "${var.helm_path}"
+resource helm_release quantum_serverless_helm {
+  #name       = "${var.helm_name}"
+  name       = "quantum-serverless-chart"
+  #chart      = "${var.helm_path}"
+  chart      = "../../helm/quantumserverless"
 
+  #values = [
+  #  "${file("${var.values_file}")}"
+  #]
   values = [
-    "${file("${var.values_file}")}"
+    file("values.yaml")
   ]
 }
 

--- a/infrastructure/terraform/ibm/helm.tf
+++ b/infrastructure/terraform/ibm/helm.tf
@@ -2,15 +2,10 @@
 # Create a helm execution
 ##############################################################################
 
-resource helm_release quantum_serverless_helm {
-  #name       = "${var.helm_name}"
+resource "helm_release" "quantum_serverless_chart" {
   name       = "quantum-serverless-chart"
-  #chart      = "${var.helm_path}"
   chart      = "../../helm/quantumserverless"
 
-  #values = [
-  #  "${file("${var.values_file}")}"
-  #]
   values = [
     file("values.yaml")
   ]

--- a/infrastructure/terraform/ibm/main.tf
+++ b/infrastructure/terraform/ibm/main.tf
@@ -24,18 +24,26 @@ provider "ibm" {
   ibmcloud_timeout = var.ibmcloud_timeout
 }
 
-data "ibm_container_vpc_cluster" "qserverless" {
-  name = module.vpc_kubernetes_cluster.kubernetes_vpc_cluster_id
-}
-
 provider "helm" {
   kubernetes {
-    host = data.ibm_container_vpc_cluster.qserverless.public_service_endpoint_url
+    host = data.ibm_container_cluster_config.quantum_serverless_cluster_config.host
+    token = data.ibm_container_cluster_config.quantum_serverless_cluster_config.token
+    cluster_ca_certificate = data.ibm_container_cluster_config.quantum_serverless_cluster_config.ca_certificate
   }
 }
 
 ##############################################################################
 
+##############################################################################
+# Cluster reference
+##############################################################################
+
+data "ibm_container_cluster_config" "quantum_serverless_cluster_config" {
+  cluster_name_id = module.vpc_kubernetes_cluster.kubernetes_vpc_cluster_id
+  resource_group_id = data.ibm_resource_group.ibmcloud_resource_group.id
+}
+
+##############################################################################
 
 ##############################################################################
 # Resource Group

--- a/infrastructure/terraform/ibm/main.tf
+++ b/infrastructure/terraform/ibm/main.tf
@@ -24,9 +24,13 @@ provider "ibm" {
   ibmcloud_timeout = var.ibmcloud_timeout
 }
 
+data "ibm_container_vpc_cluster" "qserverless" {
+  name = module.vpc_kubernetes_cluster.kubernetes_vpc_cluster_id
+}
+
 provider "helm" {
   kubernetes {
-    host = ibm_container_vpc_cluster.cluster.public_service_endpoint_url
+    host = data.ibm_container_vpc_cluster.qserverless.public_service_endpoint_url
   }
 }
 

--- a/infrastructure/terraform/ibm/outputs.tf
+++ b/infrastructure/terraform/ibm/outputs.tf
@@ -2,6 +2,11 @@
 # IKS on VPC Outputs
 ##############################################################################
 
+output "vpc_id" {
+  description = "The ID of the vpc"
+  value       = module.vpc.vpc_id
+}
+
 output "cluster_id" {
   description = "ID of the IKS on VPC Cluster"
   value       = module.vpc_kubernetes_cluster.kubernetes_vpc_cluster_id

--- a/infrastructure/terraform/ibm/values.yaml
+++ b/infrastructure/terraform/ibm/values.yaml
@@ -101,7 +101,7 @@ ray-cluster:
   fullnameOverride: ""
 
   image:
-    repository: "<RAY_CLUSTER_IMAGE>"
+    repository: "qiskit/quantum-serverless-ray-node"
     tag: "latest"
     pullPolicy: IfNotPresent
 

--- a/infrastructure/terraform/ibm/values.yaml
+++ b/infrastructure/terraform/ibm/values.yaml
@@ -160,3 +160,63 @@ kuberay-operator:
 
   batchScheduler:
     enabled: false
+
+# ===================
+# Kuberay API Server
+# ===================
+
+kuberayApiServerEnable: true
+kuberay-apiserver:
+  name: "kuberay-apiserver"
+  image:
+    repository: kuberay/apiserver
+    tag: v0.4.0
+    pullPolicy: IfNotPresent
+
+  rbacEnable: true
+  ## Install Default RBAC roles and bindings
+  rbac:
+    create: true
+    apiVersion: v1
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: "kuberay-apiserver"
+
+  containerPort:
+    - containerPort: 8888
+    - containerPort: 8887
+
+  resources:
+    limits:
+      cpu: 500m
+      memory: 500Mi
+    requests:
+      cpu: 300m
+      memory: 300Mi
+
+  service:
+    type: NodePort
+    ports:
+      - name: http
+        port: 8888
+        targetPort: 8888
+        nodePort: 31888
+      - name: rpc
+        port: 8887
+        targetPort: 8887
+        nodePort: 31887
+
+  ingress:
+    enabled: false
+
+  replicaCount: 1
+
+# ===================
+# Keycloak
+# ===================
+
+keycloakEnable: false


### PR DESCRIPTION
### Summary

This PR fix the problem that was preventing the execution of helm in the IBM Cloud terraform `apply` & `validate`.

### Details and comments

Fix #142 

- Fixed helm execution in IBM Terraform configuration: `depends_on` removed and now depends directly from the `module`.
- Improved `helm_release` naming for AWS and IBM Cloud configuration
- Updated documentation

### Terraform apply execution example

<img width="640" alt="Screenshot 2023-01-31 at 12 39 26" src="https://user-images.githubusercontent.com/9059044/215750214-10b79852-9a3f-4242-bd8f-aac15c7d5395.png">

<img width="640" alt="Screenshot 2023-01-31 at 12 40 38" src="https://user-images.githubusercontent.com/9059044/215750423-4b61841e-5cf2-423a-bcb1-791e4d0c6d0c.png">

<img width="640" alt="Screenshot 2023-01-31 at 12 43 26" src="https://user-images.githubusercontent.com/9059044/215751075-8c0f534a-f4ea-42ce-b5cc-bf59f06981b9.png">