### PR TITLE
Docs: add helm repository commands to the guide

### DIFF
--- a/docs/guides/08_multi_cloud_deployment.rst
+++ b/docs/guides/08_multi_cloud_deployment.rst
@@ -107,6 +107,8 @@ and run the next commands:
 .. code-block::
    :caption: run these commands from ./infrastructure/helm/quantumserverless folder
 
+        $ helm repo add bitnami https://charts.bitnami.com/bitnami
+        $ helm repo add kuberay https://ray-project.github.io/kuberay-helm
         $ helm dependency build
         $ helm -n <INSERT_YOUR_NAMESPACE> install quantum-serverless --create-namespace .
 


### PR DESCRIPTION
### Summary

Added the commands to add the needed repositories to download at build time the required helm charts.