### PR TITLE
Refactor provider to support CRUD ops and run_program

### DIFF
--- a/client/quantum_serverless/core/provider.py
+++ b/client/quantum_serverless/core/provider.py
@@ -29,10 +29,13 @@ Quantum serverless provider
 import logging
 from dataclasses import dataclass
 from typing import Optional, List, Dict
+from uuid import uuid4
 
 import ray
 from ray.dashboard.modules.job.sdk import JobSubmissionClient
 
+from quantum_serverless.core.job import Job
+from quantum_serverless.core.program import Program
 from quantum_serverless.exception import QuantumServerlessException
 from quantum_serverless.utils import JsonSerializable
 
@@ -56,7 +59,7 @@ class ComputeResource:
     resources: Optional[Dict[str, float]] = None
 
     def job_client(self) -> Optional[JobSubmissionClient]:
-        """Returns job client for given compute resource
+        """Return job client for given compute resource.
 
         Returns:
             job client
@@ -76,7 +79,7 @@ class ComputeResource:
         return None
 
     def context(self, **kwargs):
-        """Returns context allocated for this compute_resource."""
+        """Return context allocated for this compute_resource."""
         init_args = {
             **kwargs,
             **{
@@ -93,14 +96,14 @@ class ComputeResource:
         return ray.init(**init_args)
 
     def connection_string_interactive_mode(self) -> Optional[str]:
-        """Returns connection string to compute_resource."""
+        """Return connection string to compute_resource."""
         if self.host is not None:
             return f"ray://{self.host}:{self.port_interactive}"
         return None
 
     @classmethod
     def from_dict(cls, data: dict):
-        """Created compute_resource object form dict."""
+        """Create compute_resource object form dict."""
         return ComputeResource(
             name=data.get("name"),
             host=data.get("host"),
@@ -118,7 +121,7 @@ class ComputeResource:
 
 
 class Provider(JsonSerializable):
-    """Provider"""
+    """Provider."""
 
     def __init__(
         self,
@@ -164,7 +167,7 @@ class Provider(JsonSerializable):
         return Provider(**dictionary)
 
     def job_client(self):
-        """Returns job client for configured compute resource of provider.
+        """Return job client for configured compute resource of provider.
 
         Returns:
             job client
@@ -187,3 +190,61 @@ class Provider(JsonSerializable):
 
     def __repr__(self):
         return f"<Provider: {self.name}>"
+
+    def get_compute_resources(self) -> List[ComputeResource]:
+        """Return compute resources for provider."""
+        raise NotImplementedError
+
+    def create_compute_resource(self, resource) -> int:
+        """Create compute resource for provider."""
+        raise NotImplementedError
+
+    def delete_compute_resource(self, resource) -> int:
+        """Delete compute resource for provider."""
+        raise NotImplementedError
+
+    def run_program(self, program: Program) -> Job:
+        """Execute program as a async job.
+
+        Example:
+            >>> serverless = QuantumServerless()
+            >>> nested_program = Program(
+            >>>     "job.py",
+            >>>     arguments={"arg1": "val1"},
+            >>>     dependencies=["requests"]
+            >>> )
+            >>> job = serverless.run_program(nested_program)
+            >>> # <Job | ...>
+
+        Args:
+            program: program object
+
+        Returns:
+            Job
+        """
+        job_client = self.job_client()
+
+        if job_client is None:
+            logging.warning(  # pylint: disable=logging-fstring-interpolation
+                f"Job has not been submitted as no provider "
+                f"with remote host has been configured. "
+                f"Selected provider: {self}"
+            )
+            return None
+
+        arguments = ""
+        if program.arguments is not None:
+            arg_list = [f"--{key}={value}" for key, value in program.arguments.items()]
+            arguments = " ".join(arg_list)
+        entrypoint = f"python {program.entrypoint} {arguments}"
+
+        job_id = job_client.submit_job(
+            entrypoint=entrypoint,
+            submission_id=f"qs_{uuid4()}",
+            runtime_env={
+                "working_dir": program.working_dir,
+                "pip": program.dependencies,
+                "env_vars": program.env_vars,
+            },
+        )
+        return Job(job_id=job_id, job_client=job_client)

--- a/client/quantum_serverless/quantum_serverless.py
+++ b/client/quantum_serverless/quantum_serverless.py
@@ -114,50 +114,8 @@ class QuantumServerless:
         return self._selected_provider.job_client()
 
     def run_program(self, program: Program) -> Optional[Job]:
-        """Executes program as a async job
-
-        Example:
-            >>> serverless = QuantumServerless()
-            >>> nested_program = Program(
-            >>>     "job.py",
-            >>>     arguments={"arg1": "val1"},
-            >>>     dependencies=["requests"]
-            >>> )
-            >>> job = serverless.run_program(nested_program)
-            >>> # <Job | ...>
-
-        Args:
-            program: program object
-
-        Returns:
-            Job
-        """
-        job_client = self.job_client
-
-        if job_client is None:
-            logging.warning(  # pylint: disable=logging-fstring-interpolation
-                f"Job has not been submitted as no provider "
-                f"with remote host has been configured. "
-                f"Selected provider: {self._selected_provider}"
-            )
-            return None
-
-        arguments = ""
-        if program.arguments is not None:
-            arg_list = [f"--{key}={value}" for key, value in program.arguments.items()]
-            arguments = " ".join(arg_list)
-        entrypoint = f"python {program.entrypoint} {arguments}"
-
-        job_id = job_client.submit_job(
-            entrypoint=entrypoint,
-            submission_id=f"qs_{uuid4()}",
-            runtime_env={
-                "working_dir": program.working_dir,
-                "pip": program.dependencies,
-                "env_vars": program.env_vars,
-            },
-        )
-        return Job(job_id=job_id, job_client=job_client)
+        """Execute program as a async job."""
+        return self._selected_provider.run_program(program)
 
     def run_job(
         self,


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

Fixes: #131 

Extends provider to support CRUD operations on compute resources + move run_program to Provider class.
