### PR TITLE
Use overrides for kuberay-apiserver

### DIFF
--- a/infrastructure/helm/quantumserverless/values.yaml
+++ b/infrastructure/helm/quantumserverless/values.yaml
@@ -166,7 +166,9 @@ kuberay-operator:
 
 kuberayApiServerEnable: true
 kuberay-apiserver:
-  name: "kuberay-apiserver"
+  nameOverride: "kuberay-apiserver"
+  fullnameOverride: "kuberay-apiserver"
+ 
   image:
     repository: kuberay/apiserver
     tag: v0.4.0


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

Without this, there was an issue with the clusterrole not being named properly (it was `quantum-serverless-kuberay-apiserver` when kuberay was expecting `kuberay-apiserver`).

