### PR TITLE
Repository: custom validators

### DIFF
--- a/repository/api/serializers.py
+++ b/repository/api/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from .models import NestedProgram
+from .validators import list
 
 
 class NestedProgramSerializer(serializers.ModelSerializer):
@@ -9,3 +10,4 @@ class NestedProgramSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = NestedProgram
+        validators = [list.List(fields=["dependencies", "tags"], nullable=True)]

--- a/repository/api/serializers.py
+++ b/repository/api/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from .models import NestedProgram
-from .validators import list
+from .validators.list_validator import ListValidator
 
 
 class NestedProgramSerializer(serializers.ModelSerializer):
@@ -10,4 +10,4 @@ class NestedProgramSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = NestedProgram
-        validators = [list.List(fields=["dependencies", "tags"], nullable=True)]
+        validators = [ListValidator(fields=["dependencies", "tags"], nullable=True)]

--- a/repository/api/serializers.py
+++ b/repository/api/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from .models import NestedProgram
-from .validators.list_validator import ListValidator
+from .validators import list_validator, dict_validator
 
 
 class NestedProgramSerializer(serializers.ModelSerializer):
@@ -10,4 +10,7 @@ class NestedProgramSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = NestedProgram
-        validators = [ListValidator(fields=["dependencies", "tags"], nullable=True)]
+        validators = [
+            list_validator.ListValidator(fields=["dependencies", "tags"], nullable=True),
+            dict_validator.DictValidator(fields=["env_vars", "arguments"], nullable=True)
+        ]

--- a/repository/api/validators/dict_validator.py
+++ b/repository/api/validators/dict_validator.py
@@ -1,0 +1,34 @@
+from rest_framework import serializers
+from typing import Any, Dict, List, OrderedDict, Union
+
+
+class DictValidator:
+    """
+    TODO: description
+    """
+
+    def __init__(self, fields: List[str], nullable=True):
+        self.fields = fields
+        self.nullable = nullable
+
+    def __call__(self, attrs: OrderedDict[str, Any]):
+        error_messages = {}
+
+        for field in self.fields:
+            error_message = self.validate(field, attrs[field])
+            if error_message is not None:
+                error_messages.update(error_message)
+
+        if error_messages:
+            raise serializers.ValidationError(error_messages)
+
+    def validate(self, field: str, value: Any) -> Union[Dict[str, str], None]:
+        if value is None:
+            if not self.nullable:
+                return {f"{field}": "This field may not be null."}
+        else:
+            # Using `type` instead of `isinstance` to validate that it is a dict and no a subtype
+            value_type = type(value)
+            if value_type is not dict:
+                return {f"{field}": "This field must be a valid dict."}
+        return None

--- a/repository/api/validators/list.py
+++ b/repository/api/validators/list.py
@@ -1,0 +1,28 @@
+from rest_framework import serializers
+from typing import List
+
+
+class List:
+    """
+    TODO: description
+    """
+
+    def __init__(self, fields: List[str], nullable=True):
+        self.fields = fields
+        self.nullable = nullable
+
+    def __call__(self, attrs):
+        for field in self.fields:
+            self.validate(field, attrs[field])
+
+    def validate(self, field, value):
+        if value is None:
+            if self.nullable is False:
+                raise serializers.ValidationError(f"{field} field cannot be null.")
+        else:
+            # Using `type` instead of `isinstance` to validate that it is a list and no a subtype
+            value_type = type(value)
+            if value_type is not list:
+                raise serializers.ValidationError(f"{field} field must be a valid list.")
+
+

--- a/repository/api/validators/list.py
+++ b/repository/api/validators/list.py
@@ -18,11 +18,9 @@ class List:
     def validate(self, field, value):
         if value is None:
             if self.nullable is False:
-                raise serializers.ValidationError(f"{field} field cannot be null.")
+                raise serializers.ValidationError({f"{field}": "This field may not be null."})
         else:
             # Using `type` instead of `isinstance` to validate that it is a list and no a subtype
             value_type = type(value)
             if value_type is not list:
-                raise serializers.ValidationError(f"{field} field must be a valid list.")
-
-
+                raise serializers.ValidationError({f"{field}": "This field must be a valid list."})

--- a/repository/api/validators/list.py
+++ b/repository/api/validators/list.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from typing import List, Dict, Union
+from typing import Any, Dict, List, OrderedDict, Union
 
 
 class List:
@@ -11,7 +11,7 @@ class List:
         self.fields = fields
         self.nullable = nullable
 
-    def __call__(self, attrs):
+    def __call__(self, attrs: OrderedDict[str, Any]):
         error_messages = {}
 
         for field in self.fields:
@@ -22,9 +22,9 @@ class List:
         if error_messages:
             raise serializers.ValidationError(error_messages)
 
-    def validate(self, field: str, value) -> Union[Dict[str, str], None]:
+    def validate(self, field: str, value: Any) -> Union[Dict[str, str], None]:
         if value is None:
-            if self.nullable is False:
+            if not self.nullable:
                 return {f"{field}": "This field may not be null."}
         else:
             # Using `type` instead of `isinstance` to validate that it is a list and no a subtype

--- a/repository/api/validators/list_validator.py
+++ b/repository/api/validators/list_validator.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 from typing import Any, Dict, List, OrderedDict, Union
 
 
-class List:
+class ListValidator:
     """
     TODO: description
     """

--- a/repository/tests/core/test_v1_nested_program.py
+++ b/repository/tests/core/test_v1_nested_program.py
@@ -151,27 +151,31 @@ class NestedProgramTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(NestedProgram.objects.count(), 0)
 
-    # def test_list_validation_returns_error_400(self):
-    #     """
-    #     TODO: review test name and description
-    #     """
-    #     nested_program_input = {
-    #         "title": "Awesome nested program",
-    #         "description": "Awesome nested program description",
-    #         "entrypoint": "nested_program.py",
-    #         "working_dir": "./",
-    #         "version": "0.0.1",
-    #         "dependencies": None,
-    #         "env_vars": {"DEBUG": True},
-    #         "arguments": None,
-    #         "tags": ["dev"],
-    #         "public": True,
-    #     }
-    #     test_user = User.objects.get(username="test_user")
-    #
-    #     self.client.force_login(test_user)
-    #
-    #     url = reverse("v1:nested-programs-list")
-    #     response = self.client.post(url, data=nested_program_input, format="json")
-    #     self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+    def test_nested_program_list_validation_returns_400(self):
+        """
+        The value for dependencies and tags is a dict, a non-allowed value for these fields and return a 400
+        """
+        fields_to_check = ["dependencies", "tags"]
+        nested_program_input = {
+            "title": "Awesome nested program",
+            "description": "Awesome nested program description",
+            "entrypoint": "nested_program.py",
+            "working_dir": "./",
+            "version": "0.0.1",
+            "dependencies": {},
+            "env_vars": {"DEBUG": True},
+            "arguments": None,
+            "tags": {},
+            "public": True,
+        }
+        test_user = User.objects.get(username="test_user")
+
+        self.client.force_login(test_user)
+
+        url = reverse("v1:nested-programs-list")
+        response = self.client.post(url, data=nested_program_input, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        failed_validation_fields_list = list(response.json().keys())
+        self.assertListEqual(failed_validation_fields_list, fields_to_check)
 

--- a/repository/tests/core/test_v1_nested_program.py
+++ b/repository/tests/core/test_v1_nested_program.py
@@ -150,3 +150,28 @@ class NestedProgramTests(APITestCase):
         response = self.client.delete(url, format="json")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(NestedProgram.objects.count(), 0)
+
+    # def test_list_validation_returns_error_400(self):
+    #     """
+    #     TODO: review test name and description
+    #     """
+    #     nested_program_input = {
+    #         "title": "Awesome nested program",
+    #         "description": "Awesome nested program description",
+    #         "entrypoint": "nested_program.py",
+    #         "working_dir": "./",
+    #         "version": "0.0.1",
+    #         "dependencies": None,
+    #         "env_vars": {"DEBUG": True},
+    #         "arguments": None,
+    #         "tags": ["dev"],
+    #         "public": True,
+    #     }
+    #     test_user = User.objects.get(username="test_user")
+    #
+    #     self.client.force_login(test_user)
+    #
+    #     url = reverse("v1:nested-programs-list")
+    #     response = self.client.post(url, data=nested_program_input, format="json")
+    #     self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+

--- a/repository/tests/core/test_v1_nested_program.py
+++ b/repository/tests/core/test_v1_nested_program.py
@@ -153,7 +153,7 @@ class NestedProgramTests(APITestCase):
 
     def test_nested_program_list_validation_returns_400(self):
         """
-        The value for dependencies and tags is a dict, a non-allowed value for these fields and return a 400
+        The value for dependencies and tags is a dict, a non-allowed value for these fields and returns a 400
         """
         fields_to_check = ["dependencies", "tags"]
         nested_program_input = {
@@ -179,3 +179,30 @@ class NestedProgramTests(APITestCase):
         failed_validation_fields_list = list(response.json().keys())
         self.assertListEqual(failed_validation_fields_list, fields_to_check)
 
+    def test_nested_program_dict_validation_returns_400(self):
+        """
+        The value for env_vars and arguments is a list, a non-allowed value for these fields and returns a 400
+        """
+        fields_to_check = ["env_vars", "arguments"]
+        nested_program_input = {
+            "title": "Awesome nested program",
+            "description": "Awesome nested program description",
+            "entrypoint": "nested_program.py",
+            "working_dir": "./",
+            "version": "0.0.1",
+            "dependencies": None,
+            "env_vars": [],
+            "arguments": [],
+            "tags": ["dev"],
+            "public": True,
+        }
+        test_user = User.objects.get(username="test_user")
+
+        self.client.force_login(test_user)
+
+        url = reverse("v1:nested-programs-list")
+        response = self.client.post(url, data=nested_program_input, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        failed_validation_fields_list = list(response.json().keys())
+        self.assertListEqual(failed_validation_fields_list, fields_to_check)


### PR DESCRIPTION
### Summary

Added custom validations to support the limitations of the data types in the models. In this case we are adding two custom validators:
- One to check that a list is a list
- Another one to check that a dict is a dict

Both types are valid JSON data types but we need to restrict what kind of JSON we are introducing in those fields.

### Details and comments

Fix #156 
- Implemented a custom validator for the list fields: `dependencies` and `tags`
- Implemented a custom validator for the dict fields: `env_vars` and `arguments`
- Prepared tests to check that the validations work