### PR TITLE
Add zlib compression to circuit serializer methods

### DIFF
--- a/client/quantum_serverless/serializers/serializers.py
+++ b/client/quantum_serverless/serializers/serializers.py
@@ -31,6 +31,7 @@ Quantum serverless serializers
 """
 import base64
 import io
+import zlib
 
 import ray
 from qiskit import QuantumCircuit, qpy
@@ -53,6 +54,7 @@ def circuit_serializer(circuit: QuantumCircuit) -> str:
     buff.seek(0)
     serialized_data = buff.read()
     buff.close()
+    serialized_data = zlib.compress(serialized_data)
     return base64.standard_b64encode(serialized_data).decode("utf-8")
 
 
@@ -67,6 +69,7 @@ def circuit_deserializer(encoded_circuit: str) -> QuantumCircuit:
     """
     buff = io.BytesIO()
     decoded = base64.standard_b64decode(encoded_circuit)
+    decoded = zlib.decompress(decoded)
     buff.write(decoded)
     buff.seek(0)
     orig = qpy.load(buff)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Close #206 adding zlib compression by default into circuit serializer/deserializer methods

### Details and comments

QPY compression data is worthy in comparision with the original size of qpy format without compression