### PR TITLE
Implement method to create kuberay cluster via apiserver

### DIFF
--- a/client/.pylintrc
+++ b/client/.pylintrc
@@ -517,7 +517,7 @@ valid-metaclass-classmethod-first-arg=cls
 max-args=10
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=8
 
 # Maximum number of boolean expressions in an if statement (see R0916).
 max-bool-expr=5

--- a/client/quantum_serverless/__init__.py
+++ b/client/quantum_serverless/__init__.py
@@ -14,7 +14,14 @@
 
 from importlib_metadata import version as metadata_version, PackageNotFoundError
 
-from .core import Provider, run_qiskit_remote, get, put, get_refs_by_status
+from .core import (
+    Provider,
+    run_qiskit_remote,
+    get,
+    put,
+    get_refs_by_status,
+    KuberayProvider,
+)
 from .quantum_serverless import QuantumServerless
 from .core.program import Program
 

--- a/client/quantum_serverless/core/__init__.py
+++ b/client/quantum_serverless/core/__init__.py
@@ -55,7 +55,7 @@ State classes
     RedisStateHandler
 """
 
-from .provider import Provider, ComputeResource
+from .provider import Provider, ComputeResource, KuberayProvider
 from .decorators import remote, get, put, run_qiskit_remote, get_refs_by_status
 from .events import RedisEventHandler, EventHandler, ExecutionMessage
 from .state import RedisStateHandler, StateHandler

--- a/client/quantum_serverless/core/constants.py
+++ b/client/quantum_serverless/core/constants.py
@@ -21,3 +21,6 @@ OT_TRACEPARENT_ID_KEY = "OT_TRACEPARENT_ID_KEY"
 OT_SPAN_DEFAULT_NAME = "entrypoint"
 OT_ATTRIBUTE_PREFIX = "qs"
 OT_LABEL_CALL_LOCATION = "qs.location"
+
+# container image
+RAY_IMAGE = "qiskit/quantum-serverless-ray-node:latest-py39"

--- a/client/quantum_serverless/core/decorators.py
+++ b/client/quantum_serverless/core/decorators.py
@@ -38,7 +38,7 @@ from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapProp
 from qiskit import QuantumCircuit
 from ray.runtime_env import RuntimeEnv
 
-from quantum_serverless.core.constrants import (
+from quantum_serverless.core.constants import (
     OT_ATTRIBUTE_PREFIX,
     OT_JAEGER_HOST_KEY,
     OT_JAEGER_PORT_KEY,

--- a/client/quantum_serverless/core/events.py
+++ b/client/quantum_serverless/core/events.py
@@ -37,7 +37,7 @@ from typing import Optional, Dict, Any, Iterator, List, Union
 
 import redis
 
-from quantum_serverless.core.constrants import (
+from quantum_serverless.core.constants import (
     QS_EVENTS_REDIS_PASSWORD,
     QS_EVENTS_REDIS_PORT,
     QS_EVENTS_REDIS_HOST,

--- a/client/quantum_serverless/core/tracing.py
+++ b/client/quantum_serverless/core/tracing.py
@@ -39,7 +39,7 @@ from opentelemetry.sdk.trace.export import (
 from opentelemetry.trace import Tracer
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
-from quantum_serverless.core.constrants import (
+from quantum_serverless.core.constants import (
     OT_PROGRAM_NAME,
     OT_PROGRAM_NAME_DEFAULT,
     OT_JAEGER_HOST_KEY,


### PR DESCRIPTION
Fixes #132 

Implements the `create_compute_resource()` function for `KuberayProvider`.

Copying the docstring here as it outlines the general way the function is structured:

```
        First, create a compute_template based on the defined ComputeResource.
        If the compute_template already exists (which shouldn't be the case,
        exit silently. Otherwise, create the template. This template is
        ephemeral and will be deleted when no longer needed (either the cluster
        was created or we failed to create it and thus need to start over).
        
        Then use that template to create a KubeRay Cluster. If the cluster
        already exists, we exit silently. Users are only able to configure the
        amount of cpu/memory and the number of worker replicas. The full spec
        can be found in the KubeRay API spec under the "protoCluster"
        definition:
        https://github.com/ray-project/kuberay/blob/master/proto/swagger/cluster.swagger.json
```

I made a number of assumptions in how to approach this, happy to revise any that don't seem to be the right ones :smile: 