### PR TITLE
Ray head node proxy rework

### DIFF
--- a/infrastructure/helm/hacks/apiserver-patch.sh
+++ b/infrastructure/helm/hacks/apiserver-patch.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+LOCAL_IP=$1
+kubectl patch deployments kuberay-apiserver --type=json -p='[{"op": "add", "path": "/spec/template/spec/containers/-","value":{"image": "quay.io/gogatekeeper/gatekeeper:2.1.1","imagePullPolicy": "IfNotPresent","name": "gatekeeper","args":["--no-redirects=true","--forwarding-grant-type=client_credentials","--listen=0.0.0.0:4180","--client-id=rayapiserver","--client-secret=APISERVERSECRET-CHANGEME","--discovery-url=http://'$LOCAL_IP':31059/realms/quantumserverless","--enable-logging=true","--verbose=true","--upstream-url=http://kuberay-apiserver-service:8888/"]}}]'

--- a/infrastructure/helm/quantumserverless/templates/keycloakrealm.yaml
+++ b/infrastructure/helm/quantumserverless/templates/keycloakrealm.yaml
@@ -428,8 +428,8 @@ data:
       "otpPolicyPeriod": 30,
       "otpPolicyCodeReusable": false,
       "otpSupportedApplications": [
-        "totpAppFreeOTPName",
-        "totpAppGoogleName"
+        "totpAppGoogleName",
+        "totpAppFreeOTPName"
       ],
       "webAuthnPolicyRpEntityName": "keycloak",
       "webAuthnPolicySignatureAlgorithms": [
@@ -464,6 +464,22 @@ data:
           "totp": false,
           "emailVerified": false,
           "serviceAccountClientId": "rayapiserver",
+          "disableableCredentialTypes": [],
+          "requiredActions": [],
+          "realmRoles": [
+            "default-roles-quantumserverless"
+          ],
+          "notBefore": 0,
+          "groups": []
+        },
+        {
+          "id": "077ed198-bbc9-4cab-9e80-05715175a210",
+          "createdTimestamp": 1678221728128,
+          "username": "service-account-rayclient",
+          "enabled": true,
+          "totp": false,
+          "emailVerified": false,
+          "serviceAccountClientId": "rayclient",
           "disableableCredentialTypes": [],
           "requiredActions": [],
           "realmRoles": [
@@ -717,6 +733,7 @@ data:
             "oidc.ciba.grant.enabled": "false",
             "client.secret.creation.time": "1676907939",
             "backchannel.logout.session.required": "true",
+            "post.logout.redirect.uris": "+",
             "display.on.consent.screen": "false",
             "oauth2.device.authorization.grant.enabled": "false",
             "backchannel.logout.revoke.offline.tokens": "false"
@@ -733,6 +750,7 @@ data:
               "consentRequired": false,
               "config": {
                 "user.session.note": "clientAddress",
+                "userinfo.token.claim": "true",
                 "id.token.claim": "true",
                 "access.token.claim": "true",
                 "claim.name": "clientAddress",
@@ -747,6 +765,7 @@ data:
               "consentRequired": false,
               "config": {
                 "user.session.note": "clientHost",
+                "userinfo.token.claim": "true",
                 "id.token.claim": "true",
                 "access.token.claim": "true",
                 "claim.name": "clientHost",
@@ -761,6 +780,7 @@ data:
               "consentRequired": false,
               "config": {
                 "user.session.note": "clientId",
+                "userinfo.token.claim": "true",
                 "id.token.claim": "true",
                 "access.token.claim": "true",
                 "claim.name": "clientId",
@@ -797,7 +817,7 @@ data:
           "clientAuthenticatorType": "client-secret",
           "secret": "{{ .Values.keycloakClientSecret }}",
           "redirectUris": [
-            "http://localhost/oauth2/callback"
+            "http://localhost/oauth/callback"
           ],
           "webOrigins": [],
           "notBefore": 0,
@@ -806,7 +826,7 @@ data:
           "standardFlowEnabled": true,
           "implicitFlowEnabled": false,
           "directAccessGrantsEnabled": true,
-          "serviceAccountsEnabled": false,
+          "serviceAccountsEnabled": true,
           "publicClient": false,
           "frontchannelLogout": true,
           "protocol": "openid-connect",
@@ -822,9 +842,54 @@ data:
           "authenticationFlowBindingOverrides": {},
           "fullScopeAllowed": true,
           "nodeReRegistrationTimeout": -1,
+          "protocolMappers": [
+            {
+              "id": "02612c1c-61e3-4a1e-95c1-bad38b8592e6",
+              "name": "Client Host",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usersessionmodel-note-mapper",
+              "consentRequired": false,
+              "config": {
+                "user.session.note": "clientHost",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "clientHost",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "id": "1ca437a2-24dd-4946-8803-a0a5d31cde4b",
+              "name": "Client ID",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usersessionmodel-note-mapper",
+              "consentRequired": false,
+              "config": {
+                "user.session.note": "clientId",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "clientId",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "id": "a0e05386-40ae-4e02-9676-8bc301b4afb8",
+              "name": "Client IP Address",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usersessionmodel-note-mapper",
+              "consentRequired": false,
+              "config": {
+                "user.session.note": "clientAddress",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "clientAddress",
+                "jsonType.label": "String"
+              }
+            }
+          ],
           "defaultClientScopes": [
             "web-origins",
             "acr",
+            "rayclient",
             "roles",
             "profile",
             "email"
@@ -1407,7 +1472,34 @@ data:
               "config": {
                 "included.client.audience": "rayapiserver",
                 "id.token.claim": "true",
-                "access.token.claim": "true"
+                "access.token.claim": "true",
+                "userinfo.token.claim": "true"
+              }
+            }
+          ]
+        },
+        {
+          "id": "51b3442d-0a41-432c-863c-966eb70af328",
+          "name": "rayclient",
+          "description": "",
+          "protocol": "openid-connect",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true",
+            "gui.order": "",
+            "consent.screen.text": ""
+          },
+          "protocolMappers": [
+            {
+              "id": "0eeddf67-69d7-4be3-a76b-ffc12f906836",
+              "name": "rayclient-audience",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-audience-mapper",
+              "consentRequired": false,
+              "config": {
+                "id.token.claim": "false",
+                "access.token.claim": "true",
+                "included.custom.audience": "rayclient"
               }
             }
           ]
@@ -1535,14 +1627,14 @@ data:
             "subComponents": {},
             "config": {
               "allowed-protocol-mapper-types": [
-                "oidc-sha256-pairwise-sub-mapper",
-                "oidc-usermodel-attribute-mapper",
-                "oidc-full-name-mapper",
-                "oidc-address-mapper",
-                "saml-role-list-mapper",
-                "saml-user-property-mapper",
                 "oidc-usermodel-property-mapper",
-                "saml-user-attribute-mapper"
+                "saml-user-attribute-mapper",
+                "saml-role-list-mapper",
+                "oidc-full-name-mapper",
+                "oidc-usermodel-attribute-mapper",
+                "oidc-address-mapper",
+                "saml-user-property-mapper",
+                "oidc-sha256-pairwise-sub-mapper"
               ]
             }
           },
@@ -1594,14 +1686,14 @@ data:
             "subComponents": {},
             "config": {
               "allowed-protocol-mapper-types": [
-                "oidc-address-mapper",
-                "oidc-usermodel-property-mapper",
-                "saml-role-list-mapper",
-                "saml-user-property-mapper",
                 "oidc-full-name-mapper",
+                "saml-role-list-mapper",
+                "oidc-usermodel-attribute-mapper",
+                "oidc-usermodel-property-mapper",
                 "oidc-sha256-pairwise-sub-mapper",
+                "oidc-address-mapper",
                 "saml-user-attribute-mapper",
-                "oidc-usermodel-attribute-mapper"
+                "saml-user-property-mapper"
               ]
             }
           },
@@ -1675,7 +1767,7 @@ data:
       "supportedLocales": [],
       "authenticationFlows": [
         {
-          "id": "a9a29b0f-32e5-402f-b2cb-3d9759046ee1",
+          "id": "067694ae-2f4a-4c19-909d-9d89d07bde18",
           "alias": "Account verification options",
           "description": "Method with which to verity the existing account",
           "providerId": "basic-flow",
@@ -1701,7 +1793,7 @@ data:
           ]
         },
         {
-          "id": "387701d0-7ae1-41ec-873d-c2107cd90fbe",
+          "id": "78d8625d-ac8e-4d08-84c2-8572674d171b",
           "alias": "Authentication Options",
           "description": "Authentication options.",
           "providerId": "basic-flow",
@@ -1735,7 +1827,7 @@ data:
           ]
         },
         {
-          "id": "38674533-c339-4627-b25b-5bb9081425f2",
+          "id": "8880794f-c602-4eb1-8f70-bdefcb6175de",
           "alias": "Browser - Conditional OTP",
           "description": "Flow to determine if the OTP is required for the authentication",
           "providerId": "basic-flow",
@@ -1761,7 +1853,7 @@ data:
           ]
         },
         {
-          "id": "42c97c74-7561-4c46-ab6e-a66f261baf0c",
+          "id": "4f7b0202-072e-4731-b4e7-7d4ab2eaa388",
           "alias": "Direct Grant - Conditional OTP",
           "description": "Flow to determine if the OTP is required for the authentication",
           "providerId": "basic-flow",
@@ -1787,7 +1879,7 @@ data:
           ]
         },
         {
-          "id": "412ebb8b-4794-4044-a116-3396afdbe29e",
+          "id": "4853b93e-fa79-493d-abd2-13eabfb81d10",
           "alias": "First broker login - Conditional OTP",
           "description": "Flow to determine if the OTP is required for the authentication",
           "providerId": "basic-flow",
@@ -1813,7 +1905,7 @@ data:
           ]
         },
         {
-          "id": "644fdce3-0270-4a86-9469-fa77778c41e1",
+          "id": "dd0f0dd8-9e72-4a53-bcc4-4380e3a5158e",
           "alias": "Handle Existing Account",
           "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
           "providerId": "basic-flow",
@@ -1839,7 +1931,7 @@ data:
           ]
         },
         {
-          "id": "4b20ed55-2f08-4a4e-b5a4-fb98372f3a4a",
+          "id": "3b4b99d5-cccf-46df-aa07-4978ecd6504c",
           "alias": "Reset - Conditional OTP",
           "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
           "providerId": "basic-flow",
@@ -1865,7 +1957,7 @@ data:
           ]
         },
         {
-          "id": "61b52ad6-199e-45df-9bfd-14affce3fc79",
+          "id": "10196ab6-8c1b-4bca-b0bb-afe358e093d7",
           "alias": "User creation or linking",
           "description": "Flow for the existing/non-existing user alternatives",
           "providerId": "basic-flow",
@@ -1892,7 +1984,7 @@ data:
           ]
         },
         {
-          "id": "fe8e510e-05ac-4034-a408-23e335c78eb4",
+          "id": "31bb2367-e850-4632-8128-53e5985017d7",
           "alias": "Verify Existing Account by Re-authentication",
           "description": "Reauthentication of existing account",
           "providerId": "basic-flow",
@@ -1918,7 +2010,7 @@ data:
           ]
         },
         {
-          "id": "9c7c4ea7-f617-4295-bba3-54592a6fbfd1",
+          "id": "bf0b7b15-9ccc-41d1-9789-0f2ed57cdfdb",
           "alias": "browser",
           "description": "browser based authentication",
           "providerId": "basic-flow",
@@ -1960,7 +2052,7 @@ data:
           ]
         },
         {
-          "id": "75a73b01-3181-4ace-ba5c-d5765fa02ec6",
+          "id": "8d5ba8dc-9e5e-475c-8906-af9a68e2afc4",
           "alias": "clients",
           "description": "Base authentication for clients",
           "providerId": "client-flow",
@@ -2002,7 +2094,7 @@ data:
           ]
         },
         {
-          "id": "daae1984-a148-4888-92bf-5b3787d7d9c1",
+          "id": "6111e4ae-78c7-4236-839e-0dc12fc9d7f0",
           "alias": "direct grant",
           "description": "OpenID Connect Resource Owner Grant",
           "providerId": "basic-flow",
@@ -2036,7 +2128,7 @@ data:
           ]
         },
         {
-          "id": "f55cc7b8-781d-46fc-a89a-124b8a03a778",
+          "id": "d39bfdc8-cab3-43c6-802a-4e24c232248a",
           "alias": "docker auth",
           "description": "Used by Docker clients to authenticate against the IDP",
           "providerId": "basic-flow",
@@ -2054,7 +2146,7 @@ data:
           ]
         },
         {
-          "id": "0193e573-0c77-4103-9369-23dce00cc5d4",
+          "id": "ef95d491-bd52-4544-ac52-b0e5747c6e24",
           "alias": "first broker login",
           "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
           "providerId": "basic-flow",
@@ -2081,7 +2173,7 @@ data:
           ]
         },
         {
-          "id": "0b4ac7e4-ca44-46b1-9939-9e98f90d888a",
+          "id": "362c7a3d-1581-4268-9987-687ae18e0afc",
           "alias": "forms",
           "description": "Username, password, otp and other auth forms.",
           "providerId": "basic-flow",
@@ -2107,7 +2199,7 @@ data:
           ]
         },
         {
-          "id": "4d56ed78-15ca-4457-a14b-1a9831204372",
+          "id": "44afd5d9-6be6-4d85-8f0a-24c99e23e627",
           "alias": "http challenge",
           "description": "An authentication flow based on challenge-response HTTP Authentication Schemes",
           "providerId": "basic-flow",
@@ -2133,7 +2225,7 @@ data:
           ]
         },
         {
-          "id": "8a8d4c7d-a55f-494f-9219-056eefcc562f",
+          "id": "4487dd46-2f53-475b-b893-a046ae0b836a",
           "alias": "registration",
           "description": "registration flow",
           "providerId": "basic-flow",
@@ -2152,7 +2244,7 @@ data:
           ]
         },
         {
-          "id": "afb69941-16d0-4536-a029-fc55a5cfd8a6",
+          "id": "8667bb04-c566-4f98-b276-aa2e2d53e649",
           "alias": "registration form",
           "description": "registration form",
           "providerId": "form-flow",
@@ -2194,7 +2286,7 @@ data:
           ]
         },
         {
-          "id": "9d7fc369-9439-43bf-9680-f9cf66e267b0",
+          "id": "aaa38cc9-1921-44ba-89a7-88886e4fb9f1",
           "alias": "reset credentials",
           "description": "Reset credentials for a user if they forgot their password or something",
           "providerId": "basic-flow",
@@ -2236,7 +2328,7 @@ data:
           ]
         },
         {
-          "id": "8ccf5a6b-ebf0-4ecb-a921-5661949b39dc",
+          "id": "c117c8b2-1e7b-4987-ba3e-ee82bb959621",
           "alias": "saml ecp",
           "description": "SAML ECP Profile Authentication Flow",
           "providerId": "basic-flow",
@@ -2256,14 +2348,14 @@ data:
       ],
       "authenticatorConfig": [
         {
-          "id": "b342e669-0e45-49a0-9059-5cb15936d6e5",
+          "id": "57e675ae-78f5-451e-b928-5773a1f24060",
           "alias": "create unique user config",
           "config": {
             "require.password.update.after.registration": "false"
           }
         },
         {
-          "id": "113563dc-7a40-4146-a0dc-d02f24225499",
+          "id": "1fa34648-e99d-44dd-9753-b19e052ecff2",
           "alias": "review profile config",
           "config": {
             "update.profile.on.first.login": "missing"

--- a/infrastructure/helm/quantumserverless/templates/keycloakrealm.yaml
+++ b/infrastructure/helm/quantumserverless/templates/keycloakrealm.yaml
@@ -61,8 +61,8 @@ data:
               ],
               "client": {
                 "account": [
-                  "view-profile",
-                  "manage-account"
+                  "manage-account",
+                  "view-profile"
                 ]
               }
             },
@@ -131,15 +131,15 @@ data:
                     "impersonation",
                     "manage-users",
                     "manage-identity-providers",
+                    "query-users",
                     "view-clients",
                     "view-events",
-                    "query-users",
-                    "manage-events",
                     "manage-authorization",
-                    "view-realm",
+                    "manage-events",
                     "query-groups",
-                    "view-authorization",
+                    "view-realm",
                     "manage-clients",
+                    "view-authorization",
                     "manage-realm",
                     "query-realms",
                     "create-client",
@@ -404,7 +404,8 @@ data:
               "containerId": "8cb563b9-d51a-4d1a-891d-39f40e0b5d6c",
               "attributes": {}
             }
-          ]
+          ],
+          "rayapiserver": []
         }
       },
       "groups": [],
@@ -454,6 +455,40 @@ data:
       "webAuthnPolicyPasswordlessCreateTimeout": 0,
       "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
       "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+      "users": [
+        {
+          "id": "117269c7-3630-4810-a537-1be0f0749371",
+          "createdTimestamp": 1676908028992,
+          "username": "service-account-rayapiserver",
+          "enabled": true,
+          "totp": false,
+          "emailVerified": false,
+          "serviceAccountClientId": "rayapiserver",
+          "disableableCredentialTypes": [],
+          "requiredActions": [],
+          "realmRoles": [
+            "default-roles-quantumserverless"
+          ],
+          "notBefore": 0,
+          "groups": []
+        },
+        {
+          "username": "{{ .Values.keycloakUserID }}",
+          "enabled": true,
+          "email": "user@quatunserverless.org",
+          "emailVerified": true,
+          "credentials": [
+            {
+              "type": "password",
+              "value": "{{ .Values.keycloakUserPassword }}"
+            }
+          ],
+          "clientRoles": {
+            "realm-management": [ "realm-admin" ],
+            "account": [ "manage-account" ]
+          }
+        }
+      ],
       "scopeMappings": [
         {
           "clientScope": "offline_access",
@@ -473,24 +508,6 @@ data:
           }
         ]
       },
-      "users": [
-          {
-              "username": "{{ .Values.keycloakUserID }}",
-              "enabled": true,
-              "email": "user@quatunserverless.org",
-              "emailVerified": true,
-              "credentials": [
-                  {
-                      "type": "password",
-                      "value": "{{ .Values.keycloakUserPassword }}"
-                  }
-              ],
-              "clientRoles": {
-                  "realm-management": [ "realm-admin" ],
-                  "account": [ "manage-account" ]
-              }
-          }
-      ],
       "clients": [
         {
           "id": "8cb563b9-d51a-4d1a-891d-39f40e0b5d6c",
@@ -611,7 +628,9 @@ data:
           "publicClient": true,
           "frontchannelLogout": false,
           "protocol": "openid-connect",
-          "attributes": {},
+          "attributes": {
+            "post.logout.redirect.uris": "+"
+          },
           "authenticationFlowBindingOverrides": {},
           "fullScopeAllowed": false,
           "nodeReRegistrationTimeout": 0,
@@ -649,7 +668,9 @@ data:
           "publicClient": false,
           "frontchannelLogout": false,
           "protocol": "openid-connect",
-          "attributes": {},
+          "attributes": {
+            "post.logout.redirect.uris": "+"
+          },
           "authenticationFlowBindingOverrides": {},
           "fullScopeAllowed": false,
           "nodeReRegistrationTimeout": 0,
@@ -659,6 +680,101 @@ data:
             "roles",
             "profile",
             "email"
+          ],
+          "optionalClientScopes": [
+            "address",
+            "phone",
+            "offline_access",
+            "microprofile-jwt"
+          ]
+        },
+        {
+          "id": "4f64e9b4-034d-48fd-b00b-0582e1017b71",
+          "clientId": "rayapiserver",
+          "name": "",
+          "description": "",
+          "rootUrl": "",
+          "adminUrl": "",
+          "baseUrl": "",
+          "surrogateAuthRequired": false,
+          "enabled": true,
+          "alwaysDisplayInConsole": false,
+          "clientAuthenticatorType": "client-secret",
+          "secret": "{{ .Values.keycloakApiServerSecret }}",
+          "redirectUris": [],
+          "webOrigins": [],
+          "notBefore": 0,
+          "bearerOnly": false,
+          "consentRequired": false,
+          "standardFlowEnabled": false,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": false,
+          "serviceAccountsEnabled": true,
+          "publicClient": false,
+          "frontchannelLogout": true,
+          "protocol": "openid-connect",
+          "attributes": {
+            "oidc.ciba.grant.enabled": "false",
+            "client.secret.creation.time": "1676907939",
+            "backchannel.logout.session.required": "true",
+            "display.on.consent.screen": "false",
+            "oauth2.device.authorization.grant.enabled": "false",
+            "backchannel.logout.revoke.offline.tokens": "false"
+          },
+          "authenticationFlowBindingOverrides": {},
+          "fullScopeAllowed": true,
+          "nodeReRegistrationTimeout": -1,
+          "protocolMappers": [
+            {
+              "id": "d9421bc1-c83e-4c5d-8f23-0338e2dc0a22",
+              "name": "Client IP Address",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usersessionmodel-note-mapper",
+              "consentRequired": false,
+              "config": {
+                "user.session.note": "clientAddress",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "clientAddress",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "id": "19625f49-50fd-467d-81ca-24c84139133f",
+              "name": "Client Host",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usersessionmodel-note-mapper",
+              "consentRequired": false,
+              "config": {
+                "user.session.note": "clientHost",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "clientHost",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "id": "48c6d133-d94e-4450-8bfe-16ab8c8ae2ad",
+              "name": "Client ID",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usersessionmodel-note-mapper",
+              "consentRequired": false,
+              "config": {
+                "user.session.note": "clientId",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "clientId",
+                "jsonType.label": "String"
+              }
+            }
+          ],
+          "defaultClientScopes": [
+            "web-origins",
+            "acr",
+            "roles",
+            "profile",
+            "email",
+            "rayapiserver"
           ],
           "optionalClientScopes": [
             "address",
@@ -698,6 +814,7 @@ data:
             "oidc.ciba.grant.enabled": "false",
             "client.secret.creation.time": "1675977386",
             "backchannel.logout.session.required": "true",
+            "post.logout.redirect.uris": "+",
             "display.on.consent.screen": "false",
             "oauth2.device.authorization.grant.enabled": "false",
             "backchannel.logout.revoke.offline.tokens": "false"
@@ -739,7 +856,9 @@ data:
           "publicClient": false,
           "frontchannelLogout": false,
           "protocol": "openid-connect",
-          "attributes": {},
+          "attributes": {
+            "post.logout.redirect.uris": "+"
+          },
           "authenticationFlowBindingOverrides": {},
           "fullScopeAllowed": false,
           "nodeReRegistrationTimeout": 0,
@@ -1175,6 +1294,7 @@ data:
               "consentRequired": false,
               "config": {
                 "multivalued": "true",
+                "userinfo.token.claim": "true",
                 "user.attribute": "foo",
                 "id.token.claim": "true",
                 "access.token.claim": "true",
@@ -1259,6 +1379,33 @@ data:
               "protocolMapper": "oidc-acr-mapper",
               "consentRequired": false,
               "config": {
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "userinfo.token.claim": "true"
+              }
+            }
+          ]
+        },
+        {
+          "id": "448b9039-0117-444d-a829-55ceaf53745a",
+          "name": "rayapiserver",
+          "description": "",
+          "protocol": "openid-connect",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true",
+            "gui.order": "",
+            "consent.screen.text": ""
+          },
+          "protocolMappers": [
+            {
+              "id": "946a541e-d0de-4126-8dd3-fc55ac79f934",
+              "name": "rayapiserver",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-audience-mapper",
+              "consentRequired": false,
+              "config": {
+                "included.client.audience": "rayapiserver",
                 "id.token.claim": "true",
                 "access.token.claim": "true"
               }
@@ -1388,14 +1535,14 @@ data:
             "subComponents": {},
             "config": {
               "allowed-protocol-mapper-types": [
-                "oidc-usermodel-attribute-mapper",
-                "saml-role-list-mapper",
-                "oidc-address-mapper",
-                "saml-user-attribute-mapper",
-                "saml-user-property-mapper",
                 "oidc-sha256-pairwise-sub-mapper",
+                "oidc-usermodel-attribute-mapper",
                 "oidc-full-name-mapper",
-                "oidc-usermodel-property-mapper"
+                "oidc-address-mapper",
+                "saml-role-list-mapper",
+                "saml-user-property-mapper",
+                "oidc-usermodel-property-mapper",
+                "saml-user-attribute-mapper"
               ]
             }
           },
@@ -1447,14 +1594,14 @@ data:
             "subComponents": {},
             "config": {
               "allowed-protocol-mapper-types": [
-                "oidc-usermodel-property-mapper",
                 "oidc-address-mapper",
+                "oidc-usermodel-property-mapper",
+                "saml-role-list-mapper",
+                "saml-user-property-mapper",
                 "oidc-full-name-mapper",
                 "oidc-sha256-pairwise-sub-mapper",
                 "saml-user-attribute-mapper",
-                "saml-user-property-mapper",
-                "oidc-usermodel-attribute-mapper",
-                "saml-role-list-mapper"
+                "oidc-usermodel-attribute-mapper"
               ]
             }
           },
@@ -1528,7 +1675,7 @@ data:
       "supportedLocales": [],
       "authenticationFlows": [
         {
-          "id": "854e8ac1-48b0-4474-89a5-20decfc5e5be",
+          "id": "a9a29b0f-32e5-402f-b2cb-3d9759046ee1",
           "alias": "Account verification options",
           "description": "Method with which to verity the existing account",
           "providerId": "basic-flow",
@@ -1554,7 +1701,7 @@ data:
           ]
         },
         {
-          "id": "618f0c4c-98f2-4f37-81aa-3f73c560dfe1",
+          "id": "387701d0-7ae1-41ec-873d-c2107cd90fbe",
           "alias": "Authentication Options",
           "description": "Authentication options.",
           "providerId": "basic-flow",
@@ -1588,7 +1735,7 @@ data:
           ]
         },
         {
-          "id": "1275a6e7-9e48-47d7-a938-4f8d801ed7b5",
+          "id": "38674533-c339-4627-b25b-5bb9081425f2",
           "alias": "Browser - Conditional OTP",
           "description": "Flow to determine if the OTP is required for the authentication",
           "providerId": "basic-flow",
@@ -1614,7 +1761,7 @@ data:
           ]
         },
         {
-          "id": "6a47d229-42eb-44fe-85c5-dc9b74a70a6e",
+          "id": "42c97c74-7561-4c46-ab6e-a66f261baf0c",
           "alias": "Direct Grant - Conditional OTP",
           "description": "Flow to determine if the OTP is required for the authentication",
           "providerId": "basic-flow",
@@ -1640,7 +1787,7 @@ data:
           ]
         },
         {
-          "id": "09823e33-577b-4d88-bdee-7d614de60c06",
+          "id": "412ebb8b-4794-4044-a116-3396afdbe29e",
           "alias": "First broker login - Conditional OTP",
           "description": "Flow to determine if the OTP is required for the authentication",
           "providerId": "basic-flow",
@@ -1666,7 +1813,7 @@ data:
           ]
         },
         {
-          "id": "b2f6d588-06fc-4252-a7a6-c34570e894df",
+          "id": "644fdce3-0270-4a86-9469-fa77778c41e1",
           "alias": "Handle Existing Account",
           "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
           "providerId": "basic-flow",
@@ -1692,7 +1839,7 @@ data:
           ]
         },
         {
-          "id": "f26444b7-4afd-4409-ad7d-66d74e839786",
+          "id": "4b20ed55-2f08-4a4e-b5a4-fb98372f3a4a",
           "alias": "Reset - Conditional OTP",
           "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
           "providerId": "basic-flow",
@@ -1718,7 +1865,7 @@ data:
           ]
         },
         {
-          "id": "500a6725-725b-41df-9106-67f7cb0c07a1",
+          "id": "61b52ad6-199e-45df-9bfd-14affce3fc79",
           "alias": "User creation or linking",
           "description": "Flow for the existing/non-existing user alternatives",
           "providerId": "basic-flow",
@@ -1745,7 +1892,7 @@ data:
           ]
         },
         {
-          "id": "9dbe02d9-6bed-4398-a0d9-542ed33b6a5e",
+          "id": "fe8e510e-05ac-4034-a408-23e335c78eb4",
           "alias": "Verify Existing Account by Re-authentication",
           "description": "Reauthentication of existing account",
           "providerId": "basic-flow",
@@ -1771,7 +1918,7 @@ data:
           ]
         },
         {
-          "id": "ccd62e41-93ca-466b-a9cc-dce6d8681fea",
+          "id": "9c7c4ea7-f617-4295-bba3-54592a6fbfd1",
           "alias": "browser",
           "description": "browser based authentication",
           "providerId": "basic-flow",
@@ -1813,7 +1960,7 @@ data:
           ]
         },
         {
-          "id": "e712b0e4-5976-4c26-a342-1f485ab62a47",
+          "id": "75a73b01-3181-4ace-ba5c-d5765fa02ec6",
           "alias": "clients",
           "description": "Base authentication for clients",
           "providerId": "client-flow",
@@ -1855,7 +2002,7 @@ data:
           ]
         },
         {
-          "id": "dbc730d3-e622-4c76-8cab-00c9a3082016",
+          "id": "daae1984-a148-4888-92bf-5b3787d7d9c1",
           "alias": "direct grant",
           "description": "OpenID Connect Resource Owner Grant",
           "providerId": "basic-flow",
@@ -1889,7 +2036,7 @@ data:
           ]
         },
         {
-          "id": "6edf237e-acdc-48a9-87ad-2c225e878eb4",
+          "id": "f55cc7b8-781d-46fc-a89a-124b8a03a778",
           "alias": "docker auth",
           "description": "Used by Docker clients to authenticate against the IDP",
           "providerId": "basic-flow",
@@ -1907,7 +2054,7 @@ data:
           ]
         },
         {
-          "id": "93b1b6a9-8640-4cc4-a545-edd90ae562a3",
+          "id": "0193e573-0c77-4103-9369-23dce00cc5d4",
           "alias": "first broker login",
           "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
           "providerId": "basic-flow",
@@ -1934,7 +2081,7 @@ data:
           ]
         },
         {
-          "id": "4e8b551d-2b5e-4d77-b8ee-95b4c0891c8b",
+          "id": "0b4ac7e4-ca44-46b1-9939-9e98f90d888a",
           "alias": "forms",
           "description": "Username, password, otp and other auth forms.",
           "providerId": "basic-flow",
@@ -1960,7 +2107,7 @@ data:
           ]
         },
         {
-          "id": "d90cb0f6-e789-431b-912e-f3653c1d335a",
+          "id": "4d56ed78-15ca-4457-a14b-1a9831204372",
           "alias": "http challenge",
           "description": "An authentication flow based on challenge-response HTTP Authentication Schemes",
           "providerId": "basic-flow",
@@ -1986,7 +2133,7 @@ data:
           ]
         },
         {
-          "id": "58fd3368-c191-46c9-94a4-81f5c3932a71",
+          "id": "8a8d4c7d-a55f-494f-9219-056eefcc562f",
           "alias": "registration",
           "description": "registration flow",
           "providerId": "basic-flow",
@@ -2005,7 +2152,7 @@ data:
           ]
         },
         {
-          "id": "6985c3df-333d-4e57-8142-4e39dbd66ef3",
+          "id": "afb69941-16d0-4536-a029-fc55a5cfd8a6",
           "alias": "registration form",
           "description": "registration form",
           "providerId": "form-flow",
@@ -2047,7 +2194,7 @@ data:
           ]
         },
         {
-          "id": "ff3a1d8f-e0e6-442a-9bf9-048c12d4192c",
+          "id": "9d7fc369-9439-43bf-9680-f9cf66e267b0",
           "alias": "reset credentials",
           "description": "Reset credentials for a user if they forgot their password or something",
           "providerId": "basic-flow",
@@ -2089,7 +2236,7 @@ data:
           ]
         },
         {
-          "id": "45ba3a67-2acb-48e2-ad78-09e0967dcd08",
+          "id": "8ccf5a6b-ebf0-4ecb-a921-5661949b39dc",
           "alias": "saml ecp",
           "description": "SAML ECP Profile Authentication Flow",
           "providerId": "basic-flow",
@@ -2109,14 +2256,14 @@ data:
       ],
       "authenticatorConfig": [
         {
-          "id": "48b24779-4912-458a-8584-64ac5c47bf74",
+          "id": "b342e669-0e45-49a0-9059-5cb15936d6e5",
           "alias": "create unique user config",
           "config": {
             "require.password.update.after.registration": "false"
           }
         },
         {
-          "id": "615ee44c-1048-4cbb-ab76-14f68f79fd5f",
+          "id": "113563dc-7a40-4146-a0dc-d02f24225499",
           "alias": "review profile config",
           "config": {
             "update.profile.on.first.login": "missing"
@@ -2217,8 +2364,12 @@ data:
         "cibaExpiresIn": "120",
         "cibaAuthRequestedUserHint": "login_hint",
         "oauth2DeviceCodeLifespan": "600",
+        "clientOfflineSessionMaxLifespan": "0",
         "oauth2DevicePollingInterval": "5",
+        "clientSessionIdleTimeout": "0",
         "parRequestUriLifespan": "60",
+        "clientSessionMaxLifespan": "0",
+        "clientOfflineSessionIdleTimeout": "0",
         "cibaInterval": "5",
         "realmReusableOtpCode": "false"
       },

--- a/infrastructure/helm/quantumserverless/values.yaml
+++ b/infrastructure/helm/quantumserverless/values.yaml
@@ -109,21 +109,22 @@ ray-cluster:
       dashboard-host: '0.0.0.0'
     ports: [{containerPort: 10001, name: client},{containerPort: 6379, name: redis},{containerPort: 8265, name: dashboard},{containerPort: 8080, name: metrics},{containerPort: 8000, name: serve},{containerPort: 4180, name: proxy}]
     sidecarContainers:
-        - name: oauth-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.3.0
-          imagePullPolicy: IfNotPresent
-          args:
-          - --client-secret=CLIENTSECRET-CHANGEME
-          - --oidc-issuer-url=http://LOCAL-IP:31059/realms/quantumserverless
-          - --oidc-extra-audience="account"
-          - --email-domain="*"
-          - --insecure-oidc-allow-unverified-email=true
-          - --http-address=0.0.0.0:4180
-          - --cookie-secret=SECRET0123456789
-          - --provider=keycloak-oidc
+        - args:
+          - --no-redirects=false
+          - --redirection-url=http://localhost/
+          - --secure-cookie=false
+          - --forwarding-grant-type=password
+          - --listen=0.0.0.0:4180
           - --client-id=rayclient
-          - --upstream="http://HELM-RELEASE-kuberay-head-svc:8265"
-          - --redirect-url=http://localhost/oauth2/callback
+          - --client-secret=CLIENTSECRET-CHANGEME
+          - --discovery-url=http://LOCAL-IP:31059/realms/quantumserverless
+          - --enable-logging=true
+          - --verbose=true
+          - --upstream-url=http://HELM-RELEASE-kuberay-head-svc:8265/
+          image: quay.io/gogatekeeper/gatekeeper:2.1.1
+          imagePullPolicy: IfNotPresent
+          name: gatekeeper
+
   worker:
     # If you want to disable the default workergroup
     # uncomment the line below

--- a/infrastructure/helm/quantumserverless/values.yaml
+++ b/infrastructure/helm/quantumserverless/values.yaml
@@ -206,6 +206,7 @@ kuberay-apiserver:
   containerPort:
     - containerPort: 8888
     - containerPort: 8887
+    - containerPort: 4180
 
   resources:
     limits:
@@ -226,11 +227,30 @@ kuberay-apiserver:
         port: 8887
         targetPort: 8887
         nodePort: 31887
+      - name: proxy
+        port: 4180
+        targetPort: 4180
+        nodePort: 30634
 
   ingress:
     enabled: false
 
   replicaCount: 1
+
+  sidecarContainers:
+    - image: quay.io/gogatekeeper/gatekeeper:2.1.1
+      imagePullPolicy: IfNotPresent
+      name: gatekeeper
+      args:
+      - --no-redirects=true
+      - --forwarding-grant-type=client_credentials
+      - --listen=0.0.0.0:4180
+      - --client-id=rayapiserver
+      - --client-secret=APISERVERSECRET-CHANGEME
+      - --discovery-url=http://LOCAL-IP:31059/realms/quantumserverless
+      - --enable-logging=true
+      - --verbose=true
+      - --upstream-url=http://kuberay-apiserver-service:8888/
 
 # ===================
 # Keycloak 
@@ -238,6 +258,7 @@ kuberay-apiserver:
 
 keycloakEnable: true
 keycloakClientSecret: CLIENTSECRET-CHANGEME
+keycloakApiServerSecret: APISERVERSECRET-CHANGEME
 keycloakUserID: user
 keycloakUserPassword: passw0rd
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Rework the proxy sidecar of the ray head node.

### Details and comments

This rework replaces the auth2-proxy with the gatekeeper for the proxy sidecar.
This change enables `Client Credentials Grant` to access to head node.
The auth2-proxy doesn't support `Client Credentials Grant`.

The request to the head node is redirected to the login screen when the request doesn't have the access token.  The request that has the access token is routed to the head node function.

This is an example script to get the access token from the Keycloak and send a request with the access token to the head node. 
```
#!/bin/bash
API=$1
export RESPONSE=$(curl --request POST \
  --url 'http:/KEYCLOAK-IP/realms/quantumserverless/protocol/openid-connect/token' \
  --header 'content-type: application/x-www-form-urlencoded' \
  --data grant_type=password \
  --data client_id=rayclient \
  --data audience=rayclient \
  --data client_secret=CLIENTSECRET-CHANGEME \
  --data username=user \
  --data password=passw0rd)
						   
export A=$(echo $RESPONSE | jq .access_token)
echo $A
export TOKEN=${A//'"'/}

curl --request GET \
--header "authorization: Bearer $TOKEN" \
--header 'content-type: application/json' \
--url "http://HEADNODE-IP/$API"
```
