### PR TITLE
Output black diff to stdout for CI

### DIFF
--- a/client/tox.ini
+++ b/client/tox.ini
@@ -27,7 +27,7 @@ commands =
 envdir = .tox/lint
 skip_install = true
 commands =
-  black --check .
+  black --diff --check .
   pylint -rn quantum_serverless tests
   mypy --install-types --non-interactive .
 

--- a/gateway/tox.ini
+++ b/gateway/tox.ini
@@ -26,7 +26,7 @@ commands =
 envdir = .tox/lint
 skip_install = true
 commands =
-  black --check .
+  black --diff --check .
   pylint --load-plugins pylint_django --load-plugins pylint_django.checkers.migrations --django-settings-module=main.settings --ignore api.migrations -rn api main
 
 [testenv:black]

--- a/repository/tox.ini
+++ b/repository/tox.ini
@@ -26,7 +26,7 @@ commands =
 envdir = .tox/lint
 skip_install = true
 commands =
-  black --check .
+  black --diff --check .
   pylint --load-plugins pylint_django --load-plugins pylint_django.checkers.migrations --django-settings-module=main.settings --ignore api.migrations -rn api main
 
 [testenv:black]


### PR DESCRIPTION
Fixes #357 

### Summary

Updates the `black` check in the CI to use the `--diff` flag (so as to output the suggested changes to stdout). Should help newer users who run into issues with the linters when submitting PRs.


