### PR TITLE
Add prometheus metrics for repository

### DIFF
--- a/repository/api/models.py
+++ b/repository/api/models.py
@@ -23,7 +23,7 @@ def empty_dict():
     return {}
 
 
-class NestedProgram(ExportModelOperationsMixin('nestedprogram'), models.Model):
+class NestedProgram(ExportModelOperationsMixin("nestedprogram"), models.Model):
     """
     Nested Program database model.
     """

--- a/repository/api/models.py
+++ b/repository/api/models.py
@@ -6,6 +6,7 @@ Django Rest framework models for api application:
 import uuid
 from django.core.validators import FileExtensionValidator
 from django.db import models
+from django_prometheus.models import ExportModelOperationsMixin
 
 
 def empty_list():
@@ -22,7 +23,7 @@ def empty_dict():
     return {}
 
 
-class NestedProgram(models.Model):
+class NestedProgram(ExportModelOperationsMixin('nestedprogram'), models.Model):
     """
     Nested Program database model.
     """

--- a/repository/main/settings.py
+++ b/repository/main/settings.py
@@ -37,12 +37,14 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django_prometheus",
     "rest_framework",
     "drf_yasg",
     "api",
 ]
 
 MIDDLEWARE = [
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -50,6 +52,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "djano_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 ROOT_URLCONF = "main.urls"
@@ -78,7 +81,7 @@ WSGI_APPLICATION = "main.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.sqlite3",
+        "ENGINE": "django_prometheus.db.backends.sqlite3",
         "NAME": BASE_DIR / "db.sqlite3",
     }
 }

--- a/repository/main/settings.py
+++ b/repository/main/settings.py
@@ -52,7 +52,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "djano_prometheus.middleware.PrometheusAfterMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 ROOT_URLCONF = "main.urls"

--- a/repository/main/urls.py
+++ b/repository/main/urls.py
@@ -35,6 +35,7 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     re_path(r"^v1/api/", include(("api.v1.urls", "api"), namespace="v1")),
     path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
+    path("", include("django_prometheus.urls")),
     # docs
     re_path(
         r"^swagger(?P<format>\.json|\.yaml)$",

--- a/repository/requirements.txt
+++ b/repository/requirements.txt
@@ -1,6 +1,7 @@
 asgiref>=3.6.0
 Django>=4.1.7
 django-filter>=22.1
+django_prometheus>=2.2
 djangorestframework>=3.14.0
 importlib-metadata>=6.0.0
 Markdown>=3.4.3


### PR DESCRIPTION
Fixes #279 

### Summary

Adds prometheus metrics for the repository


### Details and comments

Used basic default settings as described here: https://github.com/korfuri/django-prometheus

Once this merges (and the new repository image gets built/pushed) will add a dashboard for these metrics.