### PR TITLE
Ignore local .jupyter/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,5 +96,5 @@ docs/_build/
 
 /infrastructure/helm/values/**
 .local/
-
-
+.jupyter/
+.ipython/


### PR DESCRIPTION
If one runs the getting started tutorials, several directories are created in the `docs/getting_started/` directory. This PR adds them to the `.gitignore` so they won't accidentally be committed to the repo.
