### PR TITLE
Updates gateway image build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build-ray-node:
 	docker build -t $(rayNodeImageName):$(version) -f ./infrastructure/docker/Dockerfile-ray-qiskit .
 
 build-gateway:
-	docker build -t $(gatewayImageName):$(version) -f ./infrastructure/docker/Dockerfile-gateway .
+	docker build -t $(gatewayImageName):$(version) -f ./infrastructure/docker/Dockerfile-gateway ./gateway
 
 build-repository-server:
 	docker build -t $(repositoryServerImageName):$(version) -f ./infrastructure/docker/Dockerfile-repository-server .

--- a/infrastructure/docker/Dockerfile-gateway
+++ b/infrastructure/docker/Dockerfile-gateway
@@ -1,20 +1,27 @@
-FROM registry.access.redhat.com/ubi9/python-39@sha256:89463fe3e086620617a4f6281640469ba7a7abd2f1b5be13e6cf0f46a6565516
+# pull official base image
+FROM python:3.9.16-slim-buster
 
+# set work directory
 WORKDIR /usr/src/app
 
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-USER 0
-COPY gateway .
-RUN chown -R 1001:0 /usr/src/app
-USER 1001
+# install psycopg2 dependencies
+#RUN apk update \
+#    && apk add postgresql-dev gcc python3-dev musl-dev
 
-RUN pip3 install -r requirements.txt
-RUN pip3 install -r requirements-dev.txt
+# install dependencies
+RUN pip install --upgrade pip
+COPY ./requirements.txt .
+RUN pip install -r requirements.txt
 
-RUN python manage.py migrate
+# copy project
+COPY . .
 
-EXPOSE 8000
-CMD ["python3", "manage.py", "runserver", "0.0.0.0:8000"]
+RUN sed -i 's/\r$//g' /usr/src/app/entrypoint.sh
+RUN chmod +x /usr/src/app/entrypoint.sh
+
+# run entrypoint.sh
+ENTRYPOINT ["/usr/src/app/entrypoint.sh"]


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

Fixes #404

This reverts changes to building the gateway image as introduced in #384 , mainly to move back to the slim python base image instead of UBI. (we want to get back to UBI eventually, but for now this will solve the issues from #404)

It also fixes a bug in the Makefile to use the proper docker build context.

