### PR TITLE
Use stable versions for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 services:
   jupyter:
     container_name: qs-jupyter
-    image: qiskit/quantum-serverless-notebook:nightly-py39
+    image: qiskit/quantum-serverless-notebook:0.0.6-py39
     volumes:
       - ./docs/getting_started:/home/jovyan/
     ports:
@@ -13,7 +13,7 @@ services:
       - safe-tier
   ray-head:
     container_name: ray-head
-    image: qiskit/quantum-serverless-ray-node:nightly-py39
+    image: qiskit/quantum-serverless-ray-node:0.0.6-py39
     entrypoint: [
       "ray", "start", "--head", "--port=6379",
       "--dashboard-host=0.0.0.0", "--block"
@@ -108,7 +108,7 @@ services:
       - keycloak
   repository-server:
     container_name: repository-server
-    image: docker.io/qiskit/quantum-repository-server:nightly
+    image: docker.io/qiskit/quantum-repository-server:0.0.6
     command: python manage.py runserver 0.0.0.0:8060
     ports:
       - 8060:8060


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

Introduces a distinction between the regular docker-compose file, which uses the most recent release in `docker-compose.yml` and the nightlies in `docker-compose-dev.yml`.

(note: the gateway doesn't have a release as of yet, so that one still uses the nightly)