### PR TITLE
Update apiserver version for helm

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# compose config on nightly builds
+# compose config on latest release builds
 services:
   jupyter:
     container_name: qs-jupyter

--- a/infrastructure/helm/hacks/apiserver-patch.sh
+++ b/infrastructure/helm/hacks/apiserver-patch.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-LOCAL_IP=$1
-kubectl patch deployments kuberay-apiserver --type=json -p='[{"op": "add", "path": "/spec/template/spec/containers/-","value":{"image": "quay.io/gogatekeeper/gatekeeper:2.1.1","imagePullPolicy": "IfNotPresent","name": "gatekeeper","args":["--no-redirects=true","--forwarding-grant-type=client_credentials","--listen=0.0.0.0:4180","--client-id=rayapiserver","--client-secret=APISERVERSECRET-CHANGEME","--discovery-url=http://'$LOCAL_IP':31059/realms/quantumserverless","--enable-logging=true","--verbose=true","--upstream-url=http://kuberay-apiserver-service:8888/"]}}]'

--- a/infrastructure/helm/quantumserverless/README.md
+++ b/infrastructure/helm/quantumserverless/README.md
@@ -64,18 +64,6 @@ Install from specific values file
  helm -n ray install quantum-serverless -f <PATH_TO_VALUES_FILE> --create-namespace .
 ```
 
-(temporary) Patch the kuberay apiserver service
-
-```shell
-kubectl patch svc -n ray kuberay-apiserver-service --type json  --patch '[{"op" : "replace" ,"path" : "/spec/selector" ,"value" : {"app.kubernetes.io/component": "kuberay-apiserver"}}]'
-```
-
-(temporary) Patch the kuberay-apiserver deployment
-
-```shell
-./hack/apisesrver/patch.sh <LOCAL-IP>
-```
-
 ## Helm chart versions
 
 The Quantum Serverless Chart has several internal and external dependencies. If you are interested to know what versions the project is using you can check them in the [Chart.lock file](./Chart.lock).

--- a/infrastructure/helm/quantumserverless/values.yaml
+++ b/infrastructure/helm/quantumserverless/values.yaml
@@ -187,7 +187,7 @@ kuberay-apiserver:
  
   image:
     repository: kuberay/apiserver
-    tag: v0.4.0
+    tag: v0.5.0
     pullPolicy: IfNotPresent
 
   rbacEnable: true


### PR DESCRIPTION
### Summary

Updates the kuberay apiserver to v0.5.0 in the helm chart. 

Also drops the temporary patches / hacks that were needed for the previous version (though please double check to make sure things still work as expected without them :pray: )

Also updates the comment on the docker-compose yaml to state that it uses the latest releases.
