### PR TITLE
Add kuberay-operator image to helm values

### DIFF
--- a/infrastructure/helm/quantumserverless/values.yaml
+++ b/infrastructure/helm/quantumserverless/values.yaml
@@ -144,6 +144,11 @@ kuberay-operator:
   nameOverride: "kuberay-operator"
   fullnameOverride: "kuberay-operator"
 
+  image:
+    repository: kuberay/operator
+    tag: 0.5.0
+    pullPolicy: IfNotPresent
+
   rbacEnable: true
   ## Install Default RBAC roles and bindings
   rbac:


### PR DESCRIPTION
### Summary

xref: #412 

Adds images values to helm chart, using the latest release version (0.5.0) instead of the nightly.

