### PR TITLE
Ignore .tox/ for docker builds

### DIFF
--- a/gateway/.dockerignore
+++ b/gateway/.dockerignore
@@ -26,3 +26,4 @@ web/static/CACHE
 stats
 Dockerfile
 *.sqlite3
+.tox/

--- a/repository/.dockerignore
+++ b/repository/.dockerignore
@@ -1,0 +1,2 @@
+.tox/
+__pycache__

--- a/repository/.dockerignore
+++ b/repository/.dockerignore
@@ -1,2 +1,5 @@
 .tox/
 __pycache__
+stats
+Dockerfile
+*.sqlite3


### PR DESCRIPTION
### Summary

Fixes #380 

### Details and comments

Adds `.tox/` directory to `.dockerignore` files for repository and gateway apps
