### PR TITLE
Drop volume mounts for docker compose

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -6,8 +6,6 @@ services:
       context: ./
       dockerfile: infrastructure/docker/Dockerfile-notebook
     profiles: ["jupyter", "full"]
-    volumes:
-      - ./docs/getting_started:/home/jovyan/
     ports:
       - 8888:8888
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     container_name: qs-jupyter
     image: qiskit/quantum-serverless-notebook:${VERSION:-0.0.7}-py39
     profiles: ["jupyter", "full"]
-    volumes:
-      - ./docs/getting_started:/home/jovyan/
     ports:
       - 8888:8888
     environment:


### PR DESCRIPTION
### Summary

Fixes #460 

Drop volume mounts for docker compose

### Details and comments

Tutorials / getting started docs / etc. are already included in the image, so there's no need to mount them as a volume.

