### PR TITLE
fix pyscf in ray node for arm64

### DIFF
--- a/infrastructure/docker/Dockerfile-ray-qiskit-arm64
+++ b/infrastructure/docker/Dockerfile-ray-qiskit-arm64
@@ -2,8 +2,9 @@ ARG IMAGE_PY_VERSION=py39
 FROM rayproject/ray:2.3.0-$IMAGE_PY_VERSION-aarch64
 USER $RAY_UID
 
-RUN apt-get -y update && apt-get -y install gcc build-essential libopenblas-dev
+RUN apt-get -y update && apt-get -y install gcc build-essential libopenblas-dev cmake
 COPY --chown=$RAY_UID:$RAY_UID ./client ./qs
 RUN cd ./qs && pip install .
+RUN pip install git+https://github.com/pyscf/pyscf@v2.2.1 
 RUN cd ../ 
 RUN rm -r ./qs


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

fix #461 

### Details and comments

This replaces `pyscf` in ray node image for arm64.  The image build takes very long time.
Ref: https://github.com/pyscf/pyscf/issues/1511 