### PR TITLE
Update kuberay apiserver to v0.5.1 in values.yaml

### DIFF
--- a/infrastructure/helm/quantumserverless/values.yaml
+++ b/infrastructure/helm/quantumserverless/values.yaml
@@ -191,7 +191,7 @@ kuberay-apiserver:
  
   image:
     repository: kuberay/apiserver
-    tag: v0.5.0
+    tag: v0.5.1
     pullPolicy: IfNotPresent
 
   rbacEnable: true


### PR DESCRIPTION
### Summary

xref #468 

Bumps the kuberay/apiserver to the new helm chart version (v0.5.1)

