### PR TITLE
Add circuit-knitting-toolbox to jupyter notebook image

### DIFF
--- a/infrastructure/docker/Dockerfile-notebook
+++ b/infrastructure/docker/Dockerfile-notebook
@@ -12,6 +12,8 @@ RUN pip install ipywidgets
 RUN cd ../
 RUN rm -r ./qs
 
+RUN git clone https://github.com/Qiskit-Extensions/circuit-knitting-toolbox.git ckt && cd ckt && pip install . && cd ../ && rm -r ./ckt
+
 COPY --chown=$NB_UID:$NB_UID ./docs/tutorials/ ./serverless/tutorials/
 COPY --chown=$NB_UID:$NB_UID ./docs/guides/ ./serverless/guides/
 COPY --chown=$NB_UID:$NB_UID ./docs/getting_started/ ./serverless/getting_started/


### PR DESCRIPTION
### Summary

Add CKT to jupyter notebook image

### Details and comments

It might be nice to be able to use the circuit knitting toolbox in our jupyter notebook, so this PR adds it. As there isn't a released version yet, it clones the repo and builds from source (which may or may not be the right way to go about it, open to alternatives here).