### PR TITLE
redirect ray job execution logs in dev compose

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -18,7 +18,7 @@ services:
       context: ./
       dockerfile: infrastructure/docker/Dockerfile-ray-qiskit
     entrypoint: [
-      "ray", "start", "--head", "--port=6379",
+      "env", "RAY_LOG_TO_STDERR=1", "ray", "start", "--head", "--port=6379",
       "--dashboard-host=0.0.0.0", "--block"
     ]
     environment:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
fix: #493 


### Details and comments

In the docker compose with docker-compose-dev.yml infrastructure, `docker logs "ray node container ID"` includes logs of Program setup and execution in the Ray nodes.