### PR TITLE
Set platform to amd64 in docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@
 
 version=0.0.7
 repository=qiskit
-arch=$(shell uname -p)
 
 notebookImageName=$(repository)/quantum-serverless-notebook
 rayNodeImageName=$(repository)/quantum-serverless-ray-node
@@ -21,20 +20,16 @@ build-all: build-notebook build-ray-node build-gateway build-repository-server
 push-all: push-notebook push-ray-node push-gateway push-repository-server
 
 build-notebook:
-	docker build -t $(notebookImageName):$(version) -f ./infrastructure/docker/Dockerfile-notebook .
+	docker build -t $(notebookImageName):$(version) -f ./infrastructure/docker/Dockerfile-notebook --platform=linux/amd64 .
 
 build-ray-node:
-ifeq ($(arch),arm)
-	docker build -t $(rayNodeImageName):$(version) -f ./infrastructure/docker/Dockerfile-ray-qiskit-arm64 .
-else
-	docker build -t $(rayNodeImageName):$(version) -f ./infrastructure/docker/Dockerfile-ray-qiskit .
-endif
+	docker build -t $(rayNodeImageName):$(version) -f ./infrastructure/docker/Dockerfile-ray-qiskit --platform=linux/amd64 .
 
 build-gateway:
-	docker build -t $(gatewayImageName):$(version) -f ./infrastructure/docker/Dockerfile-gateway .
+	docker build -t $(gatewayImageName):$(version) -f ./infrastructure/docker/Dockerfile-gateway --platform=linux/amd64 .
 
 build-repository-server:
-	docker build -t $(repositoryServerImageName):$(version) -f ./infrastructure/docker/Dockerfile-repository-server .
+	docker build -t $(repositoryServerImageName):$(version) -f ./infrastructure/docker/Dockerfile-repository-server --platform=linux/amd64 .
 
 push-notebook:
 	docker push $(notebookImageName):$(version)

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,6 +1,7 @@
 # compose config for running images based on local files
 services:
   jupyter:
+    platform: linux/amd64
     container_name: qs-jupyter
     build:
       context: ./
@@ -13,6 +14,7 @@ services:
     networks:
       - safe-tier
   ray-head:
+    platform: linux/amd64
     container_name: ray-head
     build:
       context: ./
@@ -31,6 +33,7 @@ services:
     networks:
       - safe-tier
   jaeger:
+    platform: linux/amd64
     image: jaegertracing/all-in-one:latest
     profiles: [ "full" ]
     environment:
@@ -47,6 +50,7 @@ services:
     networks:
       - safe-tier
   postgres:
+    platform: linux/amd64
     image: postgres
     environment:
       POSTGRES_DB: testkeycloakdb
@@ -57,6 +61,7 @@ services:
     restart:
       always
   keycloak:
+    platform: linux/amd64
     container_name: keycloak
     image: bitnami/keycloak:20.0.5-debian-11-r4
     volumes:
@@ -80,6 +85,7 @@ services:
     restart:
       always
   gateway:
+    platform: linux/amd64
     container_name: gateway
     build:
       context: ./
@@ -103,6 +109,7 @@ services:
     depends_on:
       - keycloak
   repository-server:
+    platform: linux/amd64
     container_name: repository-server
     build:
       context: ./
@@ -118,11 +125,13 @@ services:
     networks:
       - safe-tier
   prometheus:
+    platform: linux/amd64
     image: prom/prometheus:v2.43.0
     profiles: [ "full" ]
     ports:
       - 9000:9090
   loki:
+    platform: linux/amd64
     image: grafana/loki:2.7.5
     profiles: [ "full" ]
     ports:
@@ -131,6 +140,7 @@ services:
     networks:
       - safe-tier
   promtail:
+    platform: linux/amd64
     image: grafana/promtail:2.7.4
     profiles: [ "full" ]
     volumes:
@@ -139,6 +149,7 @@ services:
     networks:
       - safe-tier
   grafana:
+    platform: linux/amd64
     image: grafana/grafana:latest
     profiles: [ "full" ]
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 # compose config on latest release builds
 services:
   jupyter:
+    platform: linux/amd64
     container_name: qs-jupyter
     image: qiskit/quantum-serverless-notebook:${VERSION:-0.0.7}-py39
     profiles: ["jupyter", "full"]
@@ -11,6 +12,7 @@ services:
     networks:
       - safe-tier
   ray-head:
+    platform: linux/amd64    
     container_name: ray-head
     image: qiskit/quantum-serverless-ray-node:${VERSION:-0.0.7}-py39
     entrypoint: [
@@ -27,6 +29,7 @@ services:
     networks:
       - safe-tier
   jaeger:
+    platform: linux/amd64    
     image: jaegertracing/all-in-one:latest
     profiles: [ "full" ]
     environment:
@@ -43,6 +46,7 @@ services:
     networks:
       - safe-tier
   postgres:
+    platform: linux/amd64
     image: postgres
     environment:
       POSTGRES_DB: testkeycloakdb
@@ -53,6 +57,7 @@ services:
     restart:
       always
   keycloak:
+    platform: linux/amd64
     container_name: keycloak
     image: bitnami/keycloak:20.0.5-debian-11-r4
     volumes:
@@ -76,6 +81,7 @@ services:
     restart:
       always
   gateway:
+    platform: linux/amd64
     container_name: gateway
     image: docker.io/qiskit/quantum-serverless-gateway:${VERSION:-0.0.7}
     command: gunicorn main.wsgi:application --bind 0.0.0.0:8000 --workers=4
@@ -97,6 +103,7 @@ services:
     depends_on:
       - keycloak
   repository-server:
+    platform: linux/amd64
     container_name: repository-server
     image: docker.io/qiskit/quantum-repository-server:${VERSION:-0.0.7}
     command: gunicorn main.wsgi:application --bind 0.0.0.0:8060 --workers=4
@@ -110,11 +117,13 @@ services:
     networks:
       - safe-tier
   prometheus:
+    platform: linux/amd64
     image: prom/prometheus:v2.43.0
     profiles: [ "full" ]
     ports:
       - 9000:9090
   loki:
+    platform: linux/amd64
     image: grafana/loki:2.7.5
     profiles: [ "full" ]
     ports:
@@ -123,6 +132,7 @@ services:
     networks:
       - safe-tier
   promtail:
+    platform: linux/amd64
     image: grafana/promtail:2.7.5
     profiles: [ "full" ]
     volumes:
@@ -131,6 +141,7 @@ services:
     networks:
       - safe-tier
   grafana:
+    platform: linux/amd64
     image: grafana/grafana:latest
     profiles: [ "full" ]
     ports:


### PR DESCRIPTION
### Summary

Set `platform: linux/amd64` in docker-compose 

### Details and comments

Some of our images don't build properly for users with arm laptops (e.g. M1 Macs). One suggestion to get around this issue made in https://github.com/Qiskit-Extensions/quantum-serverless/issues/365#issuecomment-1531562851 was to explicitly set the platform to amd64. 

This PR does that for both the main and dev docker-compose files as a (potential) alternative to building separate arm64 images. Mainly want to see if this works for @pacomf and @akihikokuroda at this point...

