### PR TITLE
gateway initialization missing in helm install

### DIFF
--- a/infrastructure/helm/quantumserverless/charts/gateway/templates/deployment.yaml
+++ b/infrastructure/helm/quantumserverless/charts/gateway/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["python", "manage.py", "runserver", "0.0.0.0:8000"] #[ "gunicorn", "gateway.wsgi:application", "--bind", "0.0.0.0:8000", "--workers=3" ]
+          command: [ "/usr/src/app/entrypoint.sh", "gunicorn", "main.wsgi:application", "--bind", "0.0.0.0:8000", "--workers=3" ]
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fix #500 


### Details and comments

The contents in the `/usr/src/app/entrypoint.sh` was not executed at the initialization of the gateway pod.
