### PR TITLE
Clean up Helm install namespace / component names

### DIFF
--- a/infrastructure/helm/quantumserverless/README.md
+++ b/infrastructure/helm/quantumserverless/README.md
@@ -56,12 +56,12 @@ kind-control-plane   Ready    control-plane   5d6h   v1.25.3   172.18.0.2    <no
 
 Install from the default values file
 ```shell
-helm -n ray install quantum-serverless --create-namespace .
+helm -n quantum-serverless install quantum-serverless --create-namespace .
 ```
 
 Install from specific values file
 ```shell
- helm -n ray install quantum-serverless -f <PATH_TO_VALUES_FILE> --create-namespace .
+ helm -n quantum-serverless install quantum-serverless -f <PATH_TO_VALUES_FILE> --create-namespace .
 ```
 
 ## Helm chart versions

--- a/infrastructure/helm/quantumserverless/templates/nginxconfig.yaml
+++ b/infrastructure/helm/quantumserverless/templates/nginxconfig.yaml
@@ -2,7 +2,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: {{ .Release.Name }}-nginx-ingress-controller
+  name: nginx-ingress-controller
 data:
   proxy-buffer-size: "256k"
   proxy-buffers: "4 512k"

--- a/infrastructure/helm/quantumserverless/templates/rayingress.yaml
+++ b/infrastructure/helm/quantumserverless/templates/rayingress.yaml
@@ -14,7 +14,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: {{ .Release.Name }}-kuberay-head-svc 
+            name: kuberay-head-svc 
             port:
               number: 4180
 {{- end }}

--- a/infrastructure/helm/quantumserverless/values.yaml
+++ b/infrastructure/helm/quantumserverless/values.yaml
@@ -8,6 +8,9 @@
 
 # Ingress Nginx controller is disabled by default to not affect cloud providers' controller configuration
 nginxIngressControllerEnable: true
+nginx-ingress-controller:
+  nameOverride: "nginx-ingress-controller"
+  fullnameOverride: "nginx-ingress-controller"
 
 # ===================
 # Gateway configs
@@ -15,6 +18,9 @@ nginxIngressControllerEnable: true
 
 gatewayEnable: true
 gateway:
+  nameOverride: "gateway"
+  fullnameOverride: "gateway"
+  
   image:
     pullPolicy: IfNotPresent
     tag: "0.0.7"
@@ -37,6 +43,9 @@ gateway:
 
 redisEnable: true
 redis:
+  nameOverride: "redis"
+  fullnameOverride: "redis"
+
   architecture: "standalone"
 
   global:
@@ -58,6 +67,9 @@ redis:
 jupyterEnable: true
 
 jupyter:
+  nameOverride: "jupyter"
+  fullnameOverride: "jupyter"
+
   jupyterToken: "<YOUR_JUPYTER_PASSWORD_HERE>"
 
   image:
@@ -96,7 +108,7 @@ jupyter:
 rayClusterEnable: true
 ray-cluster:
   nameOverride: "kuberay"
-  fullnameOverride: ""
+  fullnameOverride: "kuberay"
 
   image:
     repository: "qiskit/quantum-serverless-ray-node"
@@ -270,6 +282,9 @@ keycloakUserID: user
 keycloakUserPassword: passw0rd
 
 keycloak:
+  nameOverride: "keycloak"
+  fullnameOverride: "keycloak"
+
   logging:
     level: DEBUG
   service:
@@ -294,6 +309,9 @@ keycloak:
 
 repositoryEnable: true
 repository:
+  nameOverride: "repository"
+  fullnameOverride: "repository"
+
   repository: "qiskit/quantum-repository-server"
   pullPolicy: IfNotPresent
   tag: "0.0.7"
@@ -304,7 +322,21 @@ repository:
 
 prometheusEnable: true
 kube-prometheus-stack:
+  nameOverride: "prometheus"
+  fullnameOverride: "prometheus"
+
+  kube-state-metrics:
+    nameOverride: "kube-state-metrics"
+    fullnameOverride: "kube-state-metrics"
+
+  prometheus-node-exporter:
+    nameOverride: "prometheus-node-exporter"
+    fullnameOverride: "prometheus-node-exporter"
+
   grafana:
+    nameOverride: "grafana"
+    fullnameOverride: "grafana"
+
     adminPassword: passw0rd
     service:
       type: NodePort
@@ -331,6 +363,7 @@ kube-prometheus-stack:
         level: debug
       server:
         root_url: "http://localhost:32294/"
+    
 
 # ===================
 # loki
@@ -339,6 +372,9 @@ kube-prometheus-stack:
 lokiEnable: true
 
 loki:
+  nameOverride: "loki"
+  fullnameOverride: "loki"
+
   loki:
     commonConfig:
       replication_factor: 1
@@ -362,3 +398,8 @@ loki:
 # ===================
 
 promtailEnable: true
+
+promtail:
+  nameOverride: "promtail"
+  fullnameOverride: "promtail"
+

--- a/infrastructure/helm/quantumserverless/values.yaml
+++ b/infrastructure/helm/quantumserverless/values.yaml
@@ -402,7 +402,6 @@ loki:
         installOperator: false
   test:
     enabled: false
-
   
 # ===================
 # promtail
@@ -413,4 +412,3 @@ promtailEnable: true
 promtail:
   nameOverride: "promtail"
   fullnameOverride: "promtail"
-

--- a/infrastructure/helm/quantumserverless/values.yaml
+++ b/infrastructure/helm/quantumserverless/values.yaml
@@ -303,6 +303,10 @@ keycloak:
       mountPath: /opt/bitnami/keycloak/data/import
   extraStartupArgs: "--import-realm"
 
+  postgresql:
+    nameOverride: "postgresql"
+    fullnameOverride: "postgresql"
+
 # ===================
 # Quantum Repository
 # ===================
@@ -392,7 +396,14 @@ loki:
   gateway:
     service:
       type: NodePort
+  monitoring:
+    selfMonitoring:
+      grafanaAgent:
+        installOperator: false
+  test:
+    enabled: false
 
+  
 # ===================
 # promtail
 # ===================


### PR DESCRIPTION
### Summary

Fixes #498
Clean up Helm install namespace / component names

### Details and comments

* Updates install instructions to use the `quantum-serverless` namespace
* Drops release name prefix from all installed components via name overrides
* drops extra grafana install from loki chart as we already have a separate grafana instance
* updated a few templates to remove the release name