### PR TITLE
Add circuit-knitting-toolbox to jupyter notebook image

### DIFF
--- a/gateway/tests/api/test_job.py
+++ b/gateway/tests/api/test_job.py
@@ -16,7 +16,7 @@ class TestJobApi(APITestCase):
         resp = self.client.post(
             auth, {"username": "test_user", "password": "123"}, format="json"
         )
-        token = resp.data.get("access_token")
+        token = resp.data.get("access")
         self.client.credentials(HTTP_AUTHORIZATION="Bearer " + token)
 
     def test_job_non_auth_user(self):

--- a/gateway/tests/api/test_v1_program.py
+++ b/gateway/tests/api/test_v1_program.py
@@ -23,7 +23,7 @@ class TestProgramApi(APITestCase):
         response = self.client.post(
             auth, {"username": "test_user", "password": "123"}, format="json"
         )
-        token = response.data.get("access_token")
+        token = response.data.get("access")
         self.client.credentials(HTTP_AUTHORIZATION="Bearer " + token)
 
         programs_response = self.client.get(reverse("v1:programs-list"), format="json")
@@ -41,7 +41,7 @@ class TestProgramApi(APITestCase):
         response = self.client.post(
             auth, {"username": "test_user", "password": "123"}, format="json"
         )
-        token = response.data.get("access_token")
+        token = response.data.get("access")
         self.client.credentials(HTTP_AUTHORIZATION="Bearer " + token)
 
         programs_response = self.client.get(

--- a/infrastructure/docker/Dockerfile-notebook
+++ b/infrastructure/docker/Dockerfile-notebook
@@ -2,23 +2,15 @@ ARG IMAGE_PY_VERSION=3.9
 FROM jupyter/base-notebook:python-$IMAGE_PY_VERSION
 
 USER 0
-RUN apt-get -y update && apt-get -y install gcc build-essential libopenblas-dev git
+RUN apt-get -y update && apt-get -y install gcc build-essential libopenblas-dev
 
 USER $NB_UID
 
 COPY --chown=$NB_UID:$NB_UID ./client ./qs
 RUN cd ./qs && pip install .
-RUN pip install ipywidgets
+RUN pip install ipywidgets circuit-knitting-toolbox
 RUN cd ../
 RUN rm -r ./qs
-
-RUN git clone https://github.com/Qiskit-Extensions/circuit-knitting-toolbox.git ckt && \
-    cd ckt && \
-    git fetch --all --tags && \
-    git checkout tags/0.1.0 -b ckt && \
-    pip install . && \
-    cd ../ && \
-    rm -r ./ckt
 
 COPY --chown=$NB_UID:$NB_UID ./docs/running/notebooks/ ./serverless/running/
 COPY --chown=$NB_UID:$NB_UID ./docs/development/examples/ ./serverless/examples/

--- a/infrastructure/docker/Dockerfile-notebook
+++ b/infrastructure/docker/Dockerfile-notebook
@@ -2,7 +2,7 @@ ARG IMAGE_PY_VERSION=3.9
 FROM jupyter/base-notebook:python-$IMAGE_PY_VERSION
 
 USER 0
-RUN apt-get -y update && apt-get -y install gcc build-essential libopenblas-dev
+RUN apt-get -y update && apt-get -y install gcc build-essential libopenblas-dev git
 
 USER $NB_UID
 
@@ -12,8 +12,16 @@ RUN pip install ipywidgets
 RUN cd ../
 RUN rm -r ./qs
 
-COPY --chown=$NB_UID:$NB_UID ./docs/tutorials/ ./serverless/tutorials/
-COPY --chown=$NB_UID:$NB_UID ./docs/guides/ ./serverless/guides/
-COPY --chown=$NB_UID:$NB_UID ./docs/getting_started/ ./serverless/getting_started/
+RUN git clone https://github.com/Qiskit-Extensions/circuit-knitting-toolbox.git ckt && \
+    cd ckt && \
+    git fetch --all --tags && \
+    git checkout tags/0.1.0 -b ckt && \
+    pip install . && \
+    cd ../ && \
+    rm -r ./ckt
+
+COPY --chown=$NB_UID:$NB_UID ./docs/running/notebooks/ ./serverless/running/
+COPY --chown=$NB_UID:$NB_UID ./docs/development/examples/ ./serverless/examples/
+COPY --chown=$NB_UID:$NB_UID ./docs/development/guides/ ./serverless/guides/
 
 ENV JUPYTER_ENABLE_LAB=no


### PR DESCRIPTION
Fixes #510

### Summary

Add CKT to jupyter notebook image

### Details and comments

It might be nice to be able to use the circuit knitting toolbox in our jupyter notebook, so this PR adds it. As there isn't a released version yet, it clones the repo and builds from source (which may or may not be the right way to go about it, open to alternatives here).

This should also fix the [failing nightly builds](https://github.com/Qiskit-Extensions/quantum-serverless/actions/workflows/image-build-and-push-nightly.yml) for the notebook image by updating the Makefile to include the refactored notebook locations.

(seems that I can't reopen #490 but this is what I would've done there if I could reopen it)