### PR TITLE
Make Job.result a blocking command

### DIFF
--- a/client/quantum_serverless/core/job.py
+++ b/client/quantum_serverless/core/job.py
@@ -286,13 +286,11 @@ class Job:
                 while waiting for job result to populate
         """
         counter = 0
-        print(self._job_client.status(job_id))
         if wait and self._job_client.result(self.job_id) == "{}":
             logging.info("Waiting for job result.")
             counter = 0
             # Check every 3s, log a heartbeat every 30s
             while self._job_client.result(self.job_id) == "{}":
-                print(self._job_client.status(job_id))
                 time.sleep(3)
                 counter += 1
                 if counter % 10 == 0:

--- a/client/quantum_serverless/core/job.py
+++ b/client/quantum_serverless/core/job.py
@@ -276,8 +276,27 @@ class Job:
         """Returns logs of the job."""
         return self._job_client.logs(self.job_id)
 
-    def result(self):
-        """Return results of the job."""
+    def result(self, wait: bool = True, verbose: bool = False):
+        """Return results of the job.
+
+        Args:
+            wait: flag denoting whether to wait for the
+                job result to be populated before returning
+            verbose: flag denoting whether to log a heartbeat
+                while waiting for job result to populate
+        """
+        counter = 0
+        print(self._job_client.status(job_id))
+        if wait and self._job_client.result(self.job_id) == "{}":
+            logging.info("Waiting for job result.")
+            counter = 0
+            # Check every 3s, log a heartbeat every 30s
+            while self._job_client.result(self.job_id) == "{}":
+                print(self._job_client.status(job_id))
+                time.sleep(3)
+                counter += 1
+                if counter % 10 == 0:
+                    logging.info(".")
         return self._job_client.result(self.job_id)
 
     def __repr__(self):

--- a/client/quantum_serverless/core/job.py
+++ b/client/quantum_serverless/core/job.py
@@ -31,6 +31,7 @@ import json
 import logging
 import os
 import tarfile
+import time
 from typing import Dict, Any, Optional
 from uuid import uuid4
 
@@ -293,7 +294,7 @@ class Job:
             while self._job_client.result(self.job_id) == "{}":
                 time.sleep(3)
                 counter += 1
-                if counter % 10 == 0:
+                if verbose and counter % 10 == 0:
                     logging.info(".")
         return self._job_client.result(self.job_id)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->
Resolves #454 

### Summary
Job.result should be a blocking command by default. When users say `result = myjob.result(job_id)`, they will likely expect the result variable to be populated when it is used in the ensuing code. 


### Details and comments
We will add a flag for users to optionally turn off the blocking component of `result()`, and we will add a flag for enabling logging of a heartbeat while the method waits for the result object to populate.
