### PR TITLE
Build and push images to ibm container registry

### DIFF
--- a/.github/actions/icr-build-and-push-images/action.yml
+++ b/.github/actions/icr-build-and-push-images/action.yml
@@ -1,0 +1,77 @@
+name: 'Build and push images'
+description: 'Builds and pushes images to remote repository'
+inputs:
+  tag:
+    description: 'Tag of image that will be build'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Build and push node image [3.8]
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: ./infrastructure/docker/Dockerfile-ray-qiskit
+        push: true
+        tags: icr.io/quantum-public/quantum-serverless-ray-node:${{inputs.tag}}-py38
+        build-args:
+          IMAGE_PY_VERSION=py38
+    - name: Build and push node image [3.9]
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: ./infrastructure/docker/Dockerfile-ray-qiskit
+        push: true
+        tags: icr.io/quantum-public/quantum-serverless-ray-node:${{inputs.tag}}-py39
+        build-args:
+          IMAGE_PY_VERSION=py39
+    - name: Build and push node image [3.10]
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: ./infrastructure/docker/Dockerfile-ray-qiskit
+        push: true
+        tags: icr.io/quantum-public/quantum-serverless-ray-node:${{inputs.tag}}-py310
+        build-args:
+          IMAGE_PY_VERSION=py310
+    - name: Build and push jupyter [3.8]
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: ./infrastructure/docker/Dockerfile-notebook
+        push: true
+        tags: icr.io/quantum-public/quantum-serverless-notebook:${{inputs.tag}}-py38
+        build-args:
+          IMAGE_PY_VERSION=3.8
+    - name: Build and push jupyter [3.9]
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: ./infrastructure/docker/Dockerfile-notebook
+        push: true
+        tags: icr.io/quantum-public/quantum-serverless-notebook:${{inputs.tag}}-py39
+        build-args:
+          IMAGE_PY_VERSION=3.9
+    - name: Build and push jupyter [3.10]
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: ./infrastructure/docker/Dockerfile-notebook
+        push: true
+        tags: icr.io/quantum-public/quantum-serverless-notebook:${{inputs.tag}}-py310
+        build-args:
+          IMAGE_PY_VERSION=3.10
+    - name: Build and push repository server
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: ./infrastructure/docker/Dockerfile-repository-server
+        push: true
+        tags: icr.io/quantum-public/quantum-repository-server:${{inputs.tag}}
+    - name: Build and push gateway
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: ./infrastructure/docker/Dockerfile-gateway
+        push: true
+        tags: icr.io/quantum-public/quantum-serverless-gateway:${{inputs.tag}}

--- a/.github/workflows/icr-image-build-and-push.yml
+++ b/.github/workflows/icr-image-build-and-push.yml
@@ -1,0 +1,40 @@
+name: ICR | build and push
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag for images'
+        required: true
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  icr_build_and_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Login to IBM Cloud
+        uses: actions/ibmcloud-action@v1
+        with:
+          APIKEY: ${{ secrets.IBMCLOUD_API_KEY }}
+          CLOUD_REGION: global
+      - name: Build and push nightly
+        if: github.event_name == 'schedule'
+        uses: ./.github/actions/icr-build-and-push-images
+        with:
+          tag: nightly
+      - name: Build and push latest
+        if : github.event_name == 'push'
+        uses: ./.github/actions/icr-build-and-push-images
+        with:
+          tag: latest
+      - name: Build and push on dispatch
+        if : github.event_name == 'workflow_dispatch'
+        uses: ./.github/actions/icr-build-and-push-images
+        with:
+          tag: ${{ github.event.inputs.tag }}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

xref: #298 

Add actions to build and push images to IBM Container Registry


### Details and comments

Adds new workflow / actions for IBM Container Registry (as we'll be retiring DockerHub in the near future, I just duplicated the files rather than adding a registry parameter to the existing one as we can remove the Docker ones once we're happy with the ICR images).

For the image tag, we're going from `qiskit` to `icr.io/quantum-public`

For the authentication to IBM Cloud, I used https://github.com/IBM/actions-ibmcloud-cli action, which adds the IBM Cloud CLI and logs in to IBM Cloud / Container Registry.

