### PR TITLE
job logs to grafana dashboard

### DIFF
--- a/infrastructure/helm/quantumserverless/templates/fluentbitconfigmap.yaml
+++ b/infrastructure/helm/quantumserverless/templates/fluentbitconfigmap.yaml
@@ -1,0 +1,16 @@
+# Fluent Bit ConfigMap
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentbit-config
+data:
+  fluent-bit.conf: |
+    [INPUT]
+        Name tail
+        Path /tmp/ray/session_latest/logs/job-driver-raysubmit_*
+        Tag ray
+        Path_Key true
+        Refresh_Interval 5
+    [OUTPUT]
+        Name stdout
+        Match *

--- a/infrastructure/helm/quantumserverless/templates/rayjoblogs.yaml
+++ b/infrastructure/helm/quantumserverless/templates/rayjoblogs.yaml
@@ -1,0 +1,101 @@
+{{- if .Values.prometheusEnable }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    grafana_dashboard: "1"
+    release: {{ .Release.Name }}
+  name: ray-joblogs-dashboard
+  namespace: {{ .Release.Namespace }}
+data:
+  ray-joblogs.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "Job logs",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": 36,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P982945308D3682D1"
+          },
+          "gridPos": {
+            "h": 22,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "dedupStrategy": "none",
+            "enableLogDetails": true,
+            "prettifyLogMessage": false,
+            "showCommonLabels": false,
+            "showLabels": false,
+            "showTime": false,
+            "sortOrder": "Descending",
+            "wrapLogMessage": false
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "P982945308D3682D1"
+              },
+              "editorMode": "code",
+              "expr": "{container=\"ray-head-logs\"}",
+              "key": "Q-afd4b3ce-5d5b-4063-98eb-6ebf00d7c7db-0",
+              "queryType": "range",
+              "refId": "A"
+            }
+          ],
+          "title": "Job Execution Logs",
+          "type": "logs"
+        }
+      ],
+      "refresh": "",
+      "revision": 1,
+      "schemaVersion": 38,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Job Logs",
+      "uid": "87ZLGa84z",
+      "version": 1,
+      "weekStart": ""
+    }
+{{- end }}

--- a/infrastructure/helm/quantumserverless/templates/rayjoblogs.yaml
+++ b/infrastructure/helm/quantumserverless/templates/rayjoblogs.yaml
@@ -59,7 +59,7 @@ data:
             "showCommonLabels": false,
             "showLabels": false,
             "showTime": false,
-            "sortOrder": "Descending",
+            "sortOrder": "Ascending",
             "wrapLogMessage": false
           },
           "targets": [

--- a/infrastructure/helm/quantumserverless/values-ibm.yaml
+++ b/infrastructure/helm/quantumserverless/values-ibm.yaml
@@ -115,6 +115,31 @@ ray-cluster:
       requests:
         cpu: "4"
         memory: "8G"
+    sidecarContainers:
+    - name: ray-head-logs
+      image: fluent/fluent-bit:1.9.6
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
+      volumeMounts:
+      - mountPath: /tmp/ray
+        name: log-volume
+      - mountPath: /fluent-bit/etc/fluent-bit.conf
+        subPath: fluent-bit.conf
+        name: fluentbit-config
+    volumeMounts:
+    - mountPath: /tmp/ray
+      name: log-volume
+    volumes:
+      - name: log-volume
+        emptyDir: {}
+      - name: fluentbit-config
+        configMap:
+          name: fluentbit-config
   worker:
     # If you want to disable the default workergroup
     # uncomment the line below

--- a/infrastructure/helm/quantumserverless/values.yaml
+++ b/infrastructure/helm/quantumserverless/values.yaml
@@ -121,6 +121,31 @@ ray-cluster:
       requests:
         cpu: "1"
         memory: "2G"
+    sidecarContainers:
+    - name: ray-head-logs
+      image: fluent/fluent-bit:1.9.6
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
+      volumeMounts:
+      - mountPath: /tmp/ray
+        name: log-volume
+      - mountPath: /fluent-bit/etc/fluent-bit.conf
+        subPath: fluent-bit.conf
+        name: fluentbit-config
+    volumeMounts:
+    - mountPath: /tmp/ray
+      name: log-volume
+    volumes:
+      - name: log-volume
+        emptyDir: {}
+      - name: fluentbit-config
+        configMap:
+          name: fluentbit-config
   worker:
     # If you want to disable the default workergroup
     # uncomment the line below


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fix #538 

The job execution logs are shown in the Grafana dashboard

### Details and comments

The Job execution logs in the ray head node are extracted by the fluent-bit sidecar container running in the ray head node to the sidecar container standard output.  It is pulled by the Promtail and pushed into Grafana dashboard (Job Logs) via Loki.
