### PR TITLE
Infra: docker-compose repository

### DIFF
--- a/docker-compose-dev-arm64.yml
+++ b/docker-compose-dev-arm64.yml
@@ -91,6 +91,7 @@ services:
     build:
       context: ./
       dockerfile: infrastructure/docker/Dockerfile-repository-server
+    profiles: [ "repository" ]
     command: gunicorn main.wsgi:application --bind 0.0.0.0:8060 --workers=4
     ports:
       - 8060:8060

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -99,6 +99,7 @@ services:
     build:
       context: ./
       dockerfile: infrastructure/docker/Dockerfile-repository-server
+    profiles: [ "repository" ]
     command: gunicorn main.wsgi:application --bind 0.0.0.0:8060 --workers=4
     ports:
       - 8060:8060

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,7 @@ services:
   repository-server:
     container_name: repository-server
     image: docker.io/qiskit/quantum-repository-server:${VERSION:-0.0.9}
+    profiles: [ "repository" ]
     command: gunicorn main.wsgi:application --bind 0.0.0.0:8060 --workers=4
     ports:
       - 8060:8060


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Hotfix for local docker-compose setup.

### Details and comments

Gateway and repository has the same application name and same table programs. Therefore migrations in both applications were creating the same table in the same database. Migration passed as it was thinking that those table existed already. 

This PR is a hotfix to make docker-compose with  `full`, `default` and `jupyter` profile work. 
Real fix will be implemented within https://github.com/Qiskit-Extensions/quantum-serverless/issues/555

Closes #552
