### PR TITLE
Make core Job.result a blocking command

### DIFF
--- a/client/quantum_serverless/core/job.py
+++ b/client/quantum_serverless/core/job.py
@@ -303,9 +303,27 @@ class Job:
         """Returns logs of the job."""
         return self._job_client.logs(self.job_id)
 
-    def result(self):
-        """Return results of the job."""
+    def result(self, wait = True, cadence = 5, verbose = False):
+        """Return results of the job.
+        Args:
+            wait: flag denoting whether to wait for the
+                job result to be populated before returning
+            verbose: flag denoting whether to log a heartbeat
+                while waiting for job result to populate
+            cadence: time to wait between checking if job has
+                been terminated
+        """
+        if wait:
+            while self._in_terminal_state():
+                time.sleep(cadence)
+                if verbose:
+                    logging.info(".")
         return self._job_client.result(self.job_id)
+
+    def _in_terminal_state(self) -> bool:
+        """Checks if job is in terminal state"""
+        terminal_states = ["STOPPED", "SUCCEEDED", "FAILED"]
+        return self.status() in terminal_states
 
     def __repr__(self):
         return f"<Job | {self.job_id}>"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->
Resolves #454 

### Summary
Job.result should be a blocking command by default. When users say `result = myjob.result(job_id)`, they will likely expect the result variable to be populated when it is used in the ensuing code. 


### Details and comments
We will add a flag for users to optionally turn off the blocking component of `result()`, and we will add a flag for enabling logging of a heartbeat while the method waits for the result object to populate. Users may also control how often to check for the result through the `cadence` argument