### PR TITLE
Revert "Add explicit support for python 3.11 (#554)"

### DIFF
--- a/.github/actions/build-and-push-images/action.yml
+++ b/.github/actions/build-and-push-images/action.yml
@@ -34,15 +34,6 @@ runs:
         tags: qiskit/quantum-serverless-ray-node:${{inputs.tag}}-py310
         build-args:
           IMAGE_PY_VERSION=py310
-    - name: Build and push node image [3.11]
-      uses: docker/build-push-action@v3
-      with:
-        context: .
-        file: ./infrastructure/docker/Dockerfile-ray-qiskit
-        push: true
-        tags: qiskit/quantum-serverless-ray-node:${{inputs.tag}}-py311
-        build-args:
-          IMAGE_PY_VERSION=py311
     - name: Build and push jupyter [3.8]
       uses: docker/build-push-action@v3
       with:
@@ -70,15 +61,6 @@ runs:
         tags: qiskit/quantum-serverless-notebook:${{inputs.tag}}-py310
         build-args:
           IMAGE_PY_VERSION=3.10
-    - name: Build and push jupyter [3.11]
-      uses: docker/build-push-action@v3
-      with:
-        context: .
-        file: ./infrastructure/docker/Dockerfile-notebook
-        push: true
-        tags: qiskit/quantum-serverless-notebook:${{inputs.tag}}-py311
-        build-args:
-          IMAGE_PY_VERSION=3.11          
     - name: Build and push repository server
       uses: docker/build-push-action@v3
       with:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Stability](https://img.shields.io/badge/stability-alpha-f4d03f.svg)](https://github.com/Qiskit-Extensions/quantum-serverless/releases)
 [![License](https://img.shields.io/github/license/qiskit-community/quantum-prototype-template?label=License)](https://github.com/qiskit-community/quantum-prototype-template/blob/main/LICENSE.txt)
 [![Code style: Black](https://img.shields.io/badge/Code%20style-Black-000.svg)](https://github.com/psf/black)
-[![Python](https://img.shields.io/badge/Python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-informational)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/Python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10-informational)](https://www.python.org/)
 [![Qiskit](https://img.shields.io/badge/Qiskit-%E2%89%A5%200.39.0-6133BD)](https://github.com/Qiskit/qiskit)
 
 # Quantum serverless

--- a/client/README.md
+++ b/client/README.md
@@ -2,7 +2,7 @@
 [![Client verify process](https://github.com/Qiskit-Extensions/quantum-serverless/actions/workflows/client-verify.yaml/badge.svg)](https://github.com/Qiskit-Extensions/quantum-serverless/actions/workflows/client-verify.yaml)
 [![License](https://img.shields.io/github/license/qiskit-community/quantum-prototype-template?label=License)](https://github.com/qiskit-community/quantum-prototype-template/blob/main/LICENSE.txt)
 [![Code style: Black](https://img.shields.io/badge/Code%20style-Black-000.svg)](https://github.com/psf/black)
-[![Python](https://img.shields.io/badge/Python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-informational)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/Python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10-informational)](https://www.python.org/)
 [![Qiskit](https://img.shields.io/badge/Qiskit-%E2%89%A5%200.39.0-6133BD)](https://github.com/Qiskit/qiskit)
 
 # Quantum Serverless client

--- a/client/setup.py
+++ b/client/setup.py
@@ -38,7 +38,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering :: Physics",
     ],
 )

--- a/client/tox.ini
+++ b/client/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.1
-envlist = py37, py38, py39, py310, py311, lint, coverage
+envlist = py37, py38, py39, py310, lint, coverage
 # CI: skip-next-line
 skipsdist = true
 # CI: skip-next-line

--- a/gateway/tox.ini
+++ b/gateway/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.1
-envlist = py38, py39, py310, py311, lint, coverage
+envlist = py38, py39, py310, lint, coverage
 # CI: skip-next-line
 skipsdist = true
 # CI: skip-next-line

--- a/repository/tox.ini
+++ b/repository/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.1
-envlist = py38, py39, py310, py311, lint, coverage
+envlist = py38, py39, py310, lint, coverage
 # CI: skip-next-line
 skipsdist = true
 # CI: skip-next-line


### PR DESCRIPTION
This reverts commit 8eaa1f665bcee1326808542dd5003bec0f880442.

Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

Ray has not released a Python 3.11 image yet, so need to remove them from the build process for the time being.

