### PR TITLE
Use envvar for provider host in demo notebooks

### DIFF
--- a/docker-compose-dev-arm64.yml
+++ b/docker-compose-dev-arm64.yml
@@ -10,6 +10,7 @@ services:
       - 8888:8888
     environment:
       - JUPYTER_TOKEN=123
+      - GATEWAY_HOST=http://gateway:8000
     networks:
       - safe-tier
   ray-head:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -10,6 +10,7 @@ services:
       - 8888:8888
     environment:
       - JUPYTER_TOKEN=123
+      - GATEWAY_HOST=http://gateway:8000
     networks:
       - safe-tier
   ray-head:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - 8888:8888
     environment:
       - JUPYTER_TOKEN=123
+      - GATEWAY_HOST=http://gateway:8000      
     networks:
       - safe-tier
   ray-head:

--- a/docs/development/examples/01_vqe.ipynb
+++ b/docs/development/examples/01_vqe.ipynb
@@ -207,7 +207,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from quantum_serverless import QuantumServerless, GatewayProvider"
+    "from quantum_serverless import QuantumServerless, GatewayProvider\n",
+    "import os"
    ]
   },
   {
@@ -230,7 +231,7 @@
     "provider = GatewayProvider(\n",
     "    username=\"user\",\n",
     "    password=\"password123\",\n",
-    "    host=\"http://gateway:8000\",\n",
+    "    host=os.environ.get(\"GATEWAY_HOST\", \"http://localhost:8000\"),\n",
     ")\n",
     "\n",
     "serverless = QuantumServerless(provider)\n",

--- a/docs/development/examples/01_vqe.ipynb
+++ b/docs/development/examples/01_vqe.ipynb
@@ -230,7 +230,7 @@
     "provider = GatewayProvider(\n",
     "    username=\"user\",\n",
     "    password=\"password123\",\n",
-    "    host=\"http://localhost:8000\",\n",
+    "    host=\"http://gateway:8000\",\n",
     ")\n",
     "\n",
     "serverless = QuantumServerless(provider)\n",

--- a/docs/development/examples/02_qaoa.ipynb
+++ b/docs/development/examples/02_qaoa.ipynb
@@ -157,7 +157,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from quantum_serverless import QuantumServerless, GatewayProvider"
+    "from quantum_serverless import QuantumServerless, GatewayProvider\n",
+    "import os"
    ]
   },
   {
@@ -180,7 +181,7 @@
     "provider = GatewayProvider(\n",
     "    username=\"user\",\n",
     "    password=\"password123\",\n",
-    "    host=\"http://gateway:8000\",\n",
+    "    host=os.environ.get(\"GATEWAY_HOST\", \"http://localhost:8000\"),\n",
     ")\n",
     "\n",
     "serverless = QuantumServerless(provider)\n",

--- a/docs/development/examples/02_qaoa.ipynb
+++ b/docs/development/examples/02_qaoa.ipynb
@@ -180,7 +180,7 @@
     "provider = GatewayProvider(\n",
     "    username=\"user\",\n",
     "    password=\"password123\",\n",
-    "    host=\"http://localhost:8000\",\n",
+    "    host=\"http://gateway:8000\",\n",
     ")\n",
     "\n",
     "serverless = QuantumServerless(provider)\n",

--- a/docs/development/examples/06_electronic_structure_problem.ipynb
+++ b/docs/development/examples/06_electronic_structure_problem.ipynb
@@ -127,7 +127,8 @@
     "    host=os.environ.get(\"GATEWAY_HOST\", \"http://localhost:8000\"),\n",
     ")\n",
     "\n",
-    "serverless = QuantumServerless(gateway_provider)"
+    "serverless = QuantumServerless(gateway_provider)\n",
+    "serverless"
    ]
   },
   {

--- a/docs/development/examples/06_electronic_structure_problem.ipynb
+++ b/docs/development/examples/06_electronic_structure_problem.ipynb
@@ -110,7 +110,8 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "from quantum_serverless import QuantumServerless, Program, GatewayProvider\n",
-    "from quantum_serverless.core import RedisStateHandler"
+    "from quantum_serverless.core import RedisStateHandler\n",
+    "import os"
    ]
   },
   {
@@ -123,7 +124,7 @@
     "gateway_provider = GatewayProvider(\n",
     "    username=\"user\",\n",
     "    password=\"password123\",\n",
-    "    host=\"http://gateway:8000\",\n",
+    "    host=os.environ.get(\"GATEWAY_HOST\", \"http://localhost:8000\"),\n",
     ")\n",
     "\n",
     "serverless = QuantumServerless(gateway_provider)"

--- a/docs/development/examples/06_electronic_structure_problem.ipynb
+++ b/docs/development/examples/06_electronic_structure_problem.ipynb
@@ -123,7 +123,7 @@
     "gateway_provider = GatewayProvider(\n",
     "    username=\"user\",\n",
     "    password=\"password123\",\n",
-    "    host=\"http://localhost:8000\",\n",
+    "    host=\"http://gateway:8000\",\n",
     ")\n",
     "\n",
     "serverless = QuantumServerless(gateway_provider)"

--- a/docs/development/examples/07_benchmark_program.ipynb
+++ b/docs/development/examples/07_benchmark_program.ipynb
@@ -62,7 +62,7 @@
     "gateway_provider = GatewayProvider(\n",
     "    username=\"user\",\n",
     "    password=\"password123\",\n",
-    "    host=\"http://localhost:8000\",\n",
+    "    host=\"http://gateway:8000\",\n",
     ")\n",
     "serverless = QuantumServerless(gateway_provider)\n",
     "serverless"

--- a/docs/development/examples/07_benchmark_program.ipynb
+++ b/docs/development/examples/07_benchmark_program.ipynb
@@ -38,7 +38,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from quantum_serverless import QuantumServerless, Program, GatewayProvider"
+    "from quantum_serverless import QuantumServerless, Program, GatewayProvider\n",
+    "import os"
    ]
   },
   {
@@ -62,7 +63,7 @@
     "gateway_provider = GatewayProvider(\n",
     "    username=\"user\",\n",
     "    password=\"password123\",\n",
-    "    host=\"http://gateway:8000\",\n",
+    "    host=os.environ.get(\"GATEWAY_HOST\", \"http://localhost:8000\"),\n",
     ")\n",
     "serverless = QuantumServerless(gateway_provider)\n",
     "serverless"

--- a/docs/running/notebooks/01_running_program.ipynb
+++ b/docs/running/notebooks/01_running_program.ipynb
@@ -49,7 +49,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from quantum_serverless import QuantumServerless, GatewayProvider"
+    "from quantum_serverless import QuantumServerless, GatewayProvider\n",
+    "import os"
    ]
   },
   {
@@ -73,7 +74,7 @@
     "provider = GatewayProvider(\n",
     "    username=\"user\",\n",
     "    password=\"password123\",\n",
-    "    host=\"http://gateway:8000\",\n",
+    "    host=os.environ.get(\"GATEWAY_HOST\", \"http://localhost:8000\"),\n",
     ")\n",
     "\n",
     "serverless = QuantumServerless(provider)\n",

--- a/docs/running/notebooks/01_running_program.ipynb
+++ b/docs/running/notebooks/01_running_program.ipynb
@@ -73,7 +73,7 @@
     "provider = GatewayProvider(\n",
     "    username=\"user\",\n",
     "    password=\"password123\",\n",
-    "    host=\"http://localhost:8000\",\n",
+    "    host=\"http://gateway:8000\",\n",
     ")\n",
     "\n",
     "serverless = QuantumServerless(provider)\n",

--- a/docs/running/notebooks/02_distributed_workloads.ipynb
+++ b/docs/running/notebooks/02_distributed_workloads.ipynb
@@ -74,7 +74,8 @@
    },
    "outputs": [],
    "source": [
-    "from quantum_serverless import QuantumServerless, GatewayProvider"
+    "from quantum_serverless import QuantumServerless, GatewayProvider\n",
+    "import os"
    ]
   },
   {
@@ -97,7 +98,7 @@
     "provider = GatewayProvider(\n",
     "    username=\"user\",\n",
     "    password=\"password123\",\n",
-    "    host=\"http://gateway:8000\",\n",
+    "    host=os.environ.get(\"GATEWAY_HOST\", \"http://localhost:8000\"),\n",
     ")\n",
     "\n",
     "serverless = QuantumServerless(provider)\n",

--- a/docs/running/notebooks/02_distributed_workloads.ipynb
+++ b/docs/running/notebooks/02_distributed_workloads.ipynb
@@ -97,7 +97,7 @@
     "provider = GatewayProvider(\n",
     "    username=\"user\",\n",
     "    password=\"password123\",\n",
-    "    host=\"http://localhost:8000\",\n",
+    "    host=\"http://gateway:8000\",\n",
     ")\n",
     "\n",
     "serverless = QuantumServerless(provider)\n",

--- a/docs/running/notebooks/03_arguments_and_results.ipynb
+++ b/docs/running/notebooks/03_arguments_and_results.ipynb
@@ -80,7 +80,7 @@
     "provider = GatewayProvider(\n",
     "    username=\"user\",\n",
     "    password=\"password123\",\n",
-    "    host=\"http://localhost:8000\",\n",
+    "    host=\"http://gateway:8000\",\n",
     ")\n",
     "\n",
     "serverless = QuantumServerless(provider)\n",

--- a/docs/running/notebooks/03_arguments_and_results.ipynb
+++ b/docs/running/notebooks/03_arguments_and_results.ipynb
@@ -57,7 +57,8 @@
    },
    "outputs": [],
    "source": [
-    "from quantum_serverless import QuantumServerless, GatewayProvider"
+    "from quantum_serverless import QuantumServerless, GatewayProvider\n",
+    "import os"
    ]
   },
   {
@@ -80,7 +81,7 @@
     "provider = GatewayProvider(\n",
     "    username=\"user\",\n",
     "    password=\"password123\",\n",
-    "    host=\"http://gateway:8000\",\n",
+    "    host=os.environ.get(\"GATEWAY_HOST\", \"http://localhost:8000\"),\n",
     ")\n",
     "\n",
     "serverless = QuantumServerless(provider)\n",

--- a/docs/running/notebooks/04_dependencies.ipynb
+++ b/docs/running/notebooks/04_dependencies.ipynb
@@ -60,7 +60,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from quantum_serverless import QuantumServerless, GatewayProvider"
+    "from quantum_serverless import QuantumServerless, GatewayProvider\n",
+    "import os"
    ]
   },
   {
@@ -83,7 +84,7 @@
     "provider = GatewayProvider(\n",
     "    username=\"user\",\n",
     "    password=\"password123\",\n",
-    "    host=\"http://gateway:8000\",\n",
+    "    host=os.environ.get(\"GATEWAY_HOST\", \"http://localhost:8000\"),\n",
     ")\n",
     "\n",
     "serverless = QuantumServerless(provider)\n",

--- a/docs/running/notebooks/04_dependencies.ipynb
+++ b/docs/running/notebooks/04_dependencies.ipynb
@@ -83,7 +83,7 @@
     "provider = GatewayProvider(\n",
     "    username=\"user\",\n",
     "    password=\"password123\",\n",
-    "    host=\"http://localhost:8000\",\n",
+    "    host=\"http://gateway:8000\",\n",
     ")\n",
     "\n",
     "serverless = QuantumServerless(provider)\n",

--- a/infrastructure/helm/quantumserverless/charts/jupyter/templates/deployment.yaml
+++ b/infrastructure/helm/quantumserverless/charts/jupyter/templates/deployment.yaml
@@ -44,6 +44,8 @@ spec:
               value: {{ .Values.jupyterToken | quote }}
             - name: QS_CLUSTER_MANAGER_ADDRESS
               value: "http://{{ .Release.Name }}-manager:{{ .Values.managerPort }}"
+            - name: GATEWAY_HOST
+              value: {{ .Values.gatewayHost }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/infrastructure/helm/quantumserverless/charts/jupyter/values.yaml
+++ b/infrastructure/helm/quantumserverless/charts/jupyter/values.yaml
@@ -5,6 +5,7 @@
 jupyterToken: "123"
 managerHost: ""
 managerPort: 5000
+GATEWAY_HOST: http://gateway:8000
 
 replicaCount: 1
 

--- a/infrastructure/helm/quantumserverless/charts/jupyter/values.yaml
+++ b/infrastructure/helm/quantumserverless/charts/jupyter/values.yaml
@@ -5,7 +5,7 @@
 jupyterToken: "123"
 managerHost: ""
 managerPort: 5000
-GATEWAY_HOST: http://gateway:8000
+gatewayHost: http://gateway:8000
 
 replicaCount: 1
 

--- a/infrastructure/helm/quantumserverless/values-ibm.yaml
+++ b/infrastructure/helm/quantumserverless/values-ibm.yaml
@@ -229,7 +229,7 @@ keycloakEnable: true
 gatewayClientSecret: GATEWAYSECRET-CHANGEME
 grafanaClientSecret: GRAFANASECRET-CHANGEME
 keycloakUserID: user
-keycloakUserPassword: passw0rd
+keycloakUserPassword: password123
 keycloak:
   logging:
     level: DEBUG

--- a/infrastructure/helm/quantumserverless/values.yaml
+++ b/infrastructure/helm/quantumserverless/values.yaml
@@ -235,7 +235,7 @@ keycloakEnable: true
 gatewayClientSecret: GATEWAYSECRET-CHANGEME
 grafanaClientSecret: GRAFANASECRET-CHANGEME
 keycloakUserID: user
-keycloakUserPassword: passw0rd
+keycloakUserPassword: password123
 keycloak:
   nameOverride: "keycloak"
   fullnameOverride: "keycloak"


### PR DESCRIPTION
### Summary

Use an environment variable for provider host in demo notebooks
See discussion in #563 

### Details and comments

* Uses `host=os.environ.get("GATEWAY_HOST", "http://localhost:8000")` in the `GatewayProvider` of the demo notebooks
* Add a default value for `GATEWAY_HOST=http://gateway:8000` to docker compose and helm values files
* Update default keycloak user password to `password123` (the same as in docker compose)