### PR TITLE
Disable loki self monitoring in helm chart

### DIFF
--- a/infrastructure/helm/quantumserverless/values.yaml
+++ b/infrastructure/helm/quantumserverless/values.yaml
@@ -359,6 +359,7 @@ loki:
       type: ClusterIP
   monitoring:
     selfMonitoring:
+      enabled: false
       grafanaAgent:
         installOperator: false
   test:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #571 
Disable loki self monitoring in helm chart

### Details and comments

Set `.selfMonitoring.enabled: false` as we're not using this capability for loki
