### PR TITLE
Upgrade container packages to latest versions

### DIFF
--- a/infrastructure/docker/Dockerfile-gateway
+++ b/infrastructure/docker/Dockerfile-gateway
@@ -7,8 +7,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
 # install psycopg2 dependencies
-RUN apt-get -y update \
-    &&  apt-get -y install gcc python3-dev
+RUN apt-get -y update && apt-get -y upgrade &&  apt-get -y install gcc python3-dev
 
 USER 0
 COPY gateway .

--- a/infrastructure/docker/Dockerfile-notebook
+++ b/infrastructure/docker/Dockerfile-notebook
@@ -2,8 +2,7 @@ ARG IMAGE_PY_VERSION=3.9
 FROM jupyter/base-notebook:python-$IMAGE_PY_VERSION
 
 USER 0
-RUN apt-get -y update && apt-get -y install gcc build-essential libopenblas-dev
-
+RUN apt-get -y update && apt-get -y upgrade && apt-get -y install gcc build-essential libopenblas-dev
 USER $NB_UID
 
 COPY --chown=$NB_UID:$NB_UID ./client ./qs

--- a/infrastructure/docker/Dockerfile-ray-qiskit
+++ b/infrastructure/docker/Dockerfile-ray-qiskit
@@ -1,6 +1,7 @@
 ARG IMAGE_PY_VERSION=py39
 
 FROM rayproject/ray:2.4.0-$IMAGE_PY_VERSION AS ray-node-amd64
+RUN apt-get -y update && apt-get -y upgrade
 USER $RAY_UID
 COPY --chown=$RAY_UID:$RAY_UID ./client ./qs
 RUN cd ./qs && pip install .
@@ -9,7 +10,7 @@ RUN rm -r ./qs
 
 FROM rayproject/ray:2.4.0-$IMAGE_PY_VERSION-aarch64 AS ray-node-arm64
 USER $RAY_UID
-RUN apt-get -y update && apt-get -y install gcc build-essential libopenblas-dev cmake
+RUN apt-get -y update && apt-get -y upgrade && apt-get -y install gcc build-essential libopenblas-dev cmake
 COPY --chown=$RAY_UID:$RAY_UID ./client ./qs
 RUN cd ./qs && pip install .
 RUN if [ $TARGETARCH == arm64 ] ; then pip install git+https://github.com/pyscf/pyscf@v2.2.1; fi

--- a/infrastructure/docker/Dockerfile-repository-server
+++ b/infrastructure/docker/Dockerfile-repository-server
@@ -7,6 +7,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
 USER 0
+RUN apt-get -y update && apt-get -y upgrade
 COPY repository .
 RUN chown -R 1001:0 /usr/src/app
 


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

Fixes #574 

We want to avoid running into security vulnerabilties in our images, so we're upgrading system packages to the latest versions via apt update/upgrade.


