### PR TITLE
Install matplotlib into notebook image

### DIFF
--- a/infrastructure/docker/Dockerfile-notebook
+++ b/infrastructure/docker/Dockerfile-notebook
@@ -8,7 +8,7 @@ USER $NB_UID
 
 COPY --chown=$NB_UID:$NB_UID ./client ./qs
 RUN cd ./qs && pip install .
-RUN pip install ipywidgets circuit-knitting-toolbox pyscf
+RUN pip install ipywidgets circuit-knitting-toolbox pyscf matplotlib
 RUN cd ../
 RUN rm -r ./qs
 


### PR DESCRIPTION
### Summary
When running the `serverless/examples/06_electronic_structure_problem.ipynb` notebook, the `import matplotlib.pyplot as plt` statement produces a `ModuleNotFound` exception:
```
   ModuleNotFoundError                       Traceback (most recent call last)
   Cell In [1], line 1
   ----> 1 import matplotlib.pyplot as plt
         3 from quantum_serverless import QuantumServerless, Program, GatewayProvider
         4 from quantum_serverless.core import RedisStateHandler

   ModuleNotFoundError: No module named 'matplotlib'
```

### Details and comments
This pull request updates `Dockerfile-notebook` to install `matplotlib` to resolve the missing module issue.

xref: https://github.com/Qiskit-Extensions/quantum-serverless/issues/483

