### PR TITLE
Unpin serverless version from quickstart

### DIFF
--- a/docs/quickstart/index.rst
+++ b/docs/quickstart/index.rst
@@ -14,7 +14,7 @@ Step 1: Install the quantum serverless package.
 .. code-block::
    :caption: Install quantum_serverless via pip.
 
-      pip install quantum_serverless==0.1.1
+      pip install quantum_serverless
 
 
 Step 2: Run infrastructure.


### PR DESCRIPTION
We've already removed the VERSION argument from docker compose. Let's unpin the. version from serverless to match it. This is one less thing to keep up with at release.

