### PR TITLE
Replacing reference to old dockerhub image in client constants

### DIFF
--- a/client/quantum_serverless/core/constants.py
+++ b/client/quantum_serverless/core/constants.py
@@ -29,7 +29,7 @@ REPO_PORT_KEY = "REPO_PORT_KEY"
 
 
 # container image
-RAY_IMAGE = "qiskit/quantum-serverless-ray-node:latest-py39"
+RAY_IMAGE = "icr.io/quantum-public/quantum-serverless-ray-node:latest-py39"
 
 # keycloak
 ENV_KEYCLOAK_REALM = "ENV_KEYCLOAK_REALM"


### PR DESCRIPTION
We'll probably drop this in the near future, but no point in leaving a busted reference...

