### PR TITLE
Rename gateway_scheduler component to scheduler

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -97,8 +97,8 @@ services:
     depends_on:
       - keycloak
       - postgres
-  gateway_scheduler:
-    container_name: gateway_scheduler
+  scheduler:
+    container_name: scheduler
     build:
       context: ./
       dockerfile: infrastructure/docker/Dockerfile-gateway

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,8 +91,8 @@ services:
     depends_on:
       - keycloak
       - postgres
-  gateway_scheduler:
-    container_name: gateway_scheduler
+  scheduler:
+    container_name: scheduler
     image: icr.io/quantum-public/quantum-serverless-gateway:${VERSION:-0.1.2}
     entrypoint: "./scripts/scheduler.sh"
     environment:

--- a/infrastructure/helm/quantumserverless/charts/gateway/templates/deployment.yaml
+++ b/infrastructure/helm/quantumserverless/charts/gateway/templates/deployment.yaml
@@ -112,7 +112,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "gateway.fullname" . }}-scheduler
+  name: scheduler
   labels:
     {{- include "gateway.labels" . | nindent 4 }}-scheduler
 spec:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This one's more of a nit, but having components named `gateway` and `gateway-scheduler` make using autocomplete for names a little slower: `G <tab> S` or `G <tab> <what does the hash string start with for the gateway pod>` instead of just `G <tab>` or `S <tab>`. 

So, in this PR we rename the scheduler component to just scheduler, in both docker compose and helm. 

### Details and comments

