### PR TITLE
use default storageclass for kind

### DIFF
--- a/infrastructure/helm/quantumserverless/templates/pvcs.yaml
+++ b/infrastructure/helm/quantumserverless/templates/pvcs.yaml
@@ -1,3 +1,16 @@
+{{ if eq .Values.platform "kind" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gateway-claim
+spec:
+  storageClassName: standard 
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+{{ else }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -26,3 +39,4 @@ spec:
   resources:
     requests:
       storage: 1Gi
+{{ end }}

--- a/infrastructure/helm/quantumserverless/values.yaml
+++ b/infrastructure/helm/quantumserverless/values.yaml
@@ -1,6 +1,7 @@
 # ===================
 # Quantum Serverless configs
 # ===================
+platform: default
 
 # ===================
 # Ingress Nginx controller configs


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
fix: #664 

Use default storageclass when `platform` is set to `kind`

### Details and comments
The default storageclass in the kind cluster is `standard`.  It works without issue.  When the chart is install in a kind cluster, an additional value `platform` must be set.  So the helm command for kind is like this:
```
helm install quantumserverless --set platform=kind https://github.com/Qiskit-Extensions/quantum-serverless/releases/download/v0.1.2/quantum-serverless-0.1.2.tgz
```

