### PR TITLE
Create new tutorial showing how to access old jobs. Show logs in two …

### DIFF
--- a/docs/running/notebooks/01_running_program.ipynb
+++ b/docs/running/notebooks/01_running_program.ipynb
@@ -7,12 +7,11 @@
    "source": [
     "# Running a program remotely\n",
     "\n",
-    "In this tutorial, we will write a basic program using Quantum Serverless. We will show how to run the program remotely and retrieve the results from the serverless client.\n",
+    "In this tutorial, we will write a basic program using Quantum Serverless. The program will be a Qiskit example that prepares a Bell state and saves the measured probability distribution.\n",
     "\n",
     "### Writing the Program\n",
     "\n",
-    "First, we need to write the program code and save it to a file called [program_1.py](./source_files/program_1.py). This program creates a two-qubit quantum circuit that prepares a Bell state, measures the result, and saves the measured probability distribution.\n",
-    "\n",
+    "First, we need to write the program code and save it to a file called [program_1.py](./source_files/program_1.py). \n",
     "The code for the program is shown below:\n",
     "\n",
     "```python\n",
@@ -23,22 +22,20 @@
     "\n",
     "from quantum_serverless import save_result\n",
     "\n",
-    "# Create a circuit\n",
     "circuit = QuantumCircuit(2)\n",
     "circuit.h(0)\n",
     "circuit.cx(0, 1)\n",
     "circuit.measure_all()\n",
     "circuit.draw()\n",
     "\n",
-    "# Instantiate a Sampler to generate a quasi-distribution of the circuit's outputs\n",
     "sampler = Sampler()\n",
     "\n",
-    "# Run the circuit and retrieve the quasi-distribution\n",
     "quasi_dists = sampler.run(circuit).result().quasi_dists\n",
     "\n",
-    "# Save the result to the serverless client\n",
     "save_result(quasi_dists)\n",
     "```\n",
+    "\n",
+    "This program creates a two-qubit quantum circuit that prepares a Bell state, measures the result, and prints the measured probability distribution.\n",
     "\n",
     "### Running the Program\n",
     "\n",
@@ -49,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "81dd7807-7180-4b87-bbf9-832b7cf29d69",
    "metadata": {},
    "outputs": [],
@@ -60,10 +57,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "acdec789-4967-48ee-8f6c-8d2b0ff57e91",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<QuantumServerless | providers [gateway-provider]>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "provider = GatewayProvider(\n",
     "    username=\"user\",\n",
@@ -90,10 +98,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "d51df836-3f22-467c-b637-5803145d5d8a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Job | a90d1665-bda8-4bde-9375-ea517bf4046b>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from quantum_serverless import Program\n",
     "\n",
@@ -117,10 +136,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "cc7ccea6-bbae-4184-ba7f-67b6c20a0b0b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'SUCCEEDED'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "job.status()"
    ]
@@ -135,10 +165,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "1dc78690-f61a-4dfe-bc0e-7007cf561a5b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'0': 0.4999999999999999, '3': 0.4999999999999999}]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "job.result()"
    ]
@@ -160,7 +201,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/docs/running/notebooks/05_retrieving_past_results.ipynb
+++ b/docs/running/notebooks/05_retrieving_past_results.ipynb
@@ -1,0 +1,231 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "66030e20-b384-4dcf-9c5f-7664f7ad1693",
+   "metadata": {},
+   "source": [
+    "# Retrieving Results from Old Jobs\n",
+    "\n",
+    "In this tutorial, we will run two programs and then retrieve the results of each program using the job IDs and the serverless client."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "81dd7807-7180-4b87-bbf9-832b7cf29d69",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from quantum_serverless import QuantumServerless, GatewayProvider\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37322958-a029-46bb-bc46-82b7ded329b5",
+   "metadata": {},
+   "source": [
+    "First, create ``GatewayProvider`` and ``QuantumServerless`` instances."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "acdec789-4967-48ee-8f6c-8d2b0ff57e91",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "provider = GatewayProvider(\n",
+    "    username=\"user\",\n",
+    "    password=\"password123\",\n",
+    "    host=os.environ.get(\"GATEWAY_HOST\", \"http://localhost:8000\"),\n",
+    ")\n",
+    "\n",
+    "serverless = QuantumServerless(provider)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e076c12a-b372-4335-bd4a-7e3e24fcca73",
+   "metadata": {},
+   "source": [
+    "Run two programs in parallel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d51df836-3f22-467c-b637-5803145d5d8a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from quantum_serverless import Program\n",
+    "\n",
+    "program1 = Program(\n",
+    "    title=\"Program 1\",\n",
+    "    entrypoint=\"program_1.py\",\n",
+    "    working_dir=\"./source_files/\"\n",
+    ")\n",
+    "program2 = Program(\n",
+    "    title=\"Program 2\",\n",
+    "    entrypoint=\"program_2.py\",\n",
+    "    working_dir=\"./source_files/\"\n",
+    ")\n",
+    "\n",
+    "job1 = serverless.run(program1)\n",
+    "job2 = serverless.run(program2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59a49dc9-cbad-4c05-a831-b0e9dc882ca0",
+   "metadata": {},
+   "source": [
+    "Retrieve the job IDs for each of the running programs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f621f786-6ba7-4ef1-8121-741f21f70233",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_id1 = job1.job_id\n",
+    "job_id2 = job2.job_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "675f9b7a-7d44-43e3-baea-0289cf29e573",
+   "metadata": {},
+   "source": [
+    "Call the blocking comand, ``Job.result()``, to ensure the results are ready in the following cells."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cc7ccea6-bbae-4184-ba7f-67b6c20a0b0b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'results': [{'0': 0.1241226701745018, '3': 0.8758773298254983},\n",
+       "  {'0': 0.0530440173818772,\n",
+       "   '1': 0.0040236866614625,\n",
+       "   '2': 0.8764487363758928,\n",
+       "   '3': 0.0664835595807676},\n",
+       "  {'0': 1.0}]}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "job1.result()\n",
+    "job2.result()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0bd294e-af9e-4817-a58d-84125e104c7f",
+   "metadata": {},
+   "source": [
+    "Retrieve the completed jobs through the serverless client, using the job IDs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1dc78690-f61a-4dfe-bc0e-7007cf561a5b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "retrieved_job1 = serverless.get_job_by_id(job_id1)\n",
+    "retrieved_job2 = serverless.get_job_by_id(job_id2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a02841bd-ca61-4b01-a726-c3ddb5469ef8",
+   "metadata": {},
+   "source": [
+    "Inspect the results of the retrieved jobs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ca1cbfee-df32-4306-988f-ef0fa31605ee",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Job 1 results: [{'0': 0.4999999999999999, '3': 0.4999999999999999}]\n",
+      "Job 2 results: {'results': [{'0': 0.1241226701745018, '3': 0.8758773298254983}, {'0': 0.0530440173818772, '1': 0.0040236866614625, '2': 0.8764487363758928, '3': 0.0664835595807676}, {'0': 1.0}]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Job 1 results: {retrieved_job1.result()}\")\n",
+    "print(f\"Job 2 results: {retrieved_job2.result()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24942f00-680e-4cea-b0e7-bc75b19565fe",
+   "metadata": {},
+   "source": [
+    "To inspect the logs from a program, access them from the ``Job`` instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "5e39caf1-1506-44de-9fbc-248e106be6b5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Job 1 logs: Running program 1...\n",
+      "Completed running program 1.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Job 1 logs: {retrieved_job1.logs()}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/running/notebooks/source_files/program_1.py
+++ b/docs/running/notebooks/source_files/program_1.py
@@ -3,6 +3,7 @@ from qiskit.primitives import Sampler
 
 from quantum_serverless import save_result
 
+print("Running program 1...")
 circuit = QuantumCircuit(2)
 circuit.h(0)
 circuit.cx(0, 1)
@@ -14,3 +15,4 @@ sampler = Sampler()
 quasi_dists = sampler.run(circuit).result().quasi_dists
 
 save_result(quasi_dists)
+print("Completed running program 1.")


### PR DESCRIPTION
…tutorials.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
We trimmed up tutorial 1 in #593 and lost any mention of printing logs or accessing past jobs through the client.

This PR introduces two changes:
 - Introduces a new tutorial 5 showing how to retrieve jobs through the client using job ID
 - Adds a couple of small print statements in tutorial one to demonstrate job logs
 - Adds a short cell in tutorials 1 and 4 showing how to retrieve logs.
     - The logs will be very short (two lines from program 1), so this won't clutter either notebook.


### Details and comments

