### PR TITLE
clean up raycluster instances at chart uninstall

### DIFF
--- a/infrastructure/helm/quantum-serverless/templates/predelete.yaml
+++ b/infrastructure/helm/quantum-serverless/templates/predelete.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      serviceAccountName: gateway
+      containers:
+      - name: pre-install-job
+        image: alpine/k8s:1.27.3
+        command: ["/bin/sh", "-c", "kubectl delete raycluster --all"]

--- a/infrastructure/helm/quantum-serverless/templates/predelete.yaml
+++ b/infrastructure/helm/quantum-serverless/templates/predelete.yaml
@@ -24,4 +24,4 @@ spec:
       containers:
       - name: pre-install-job
         image: alpine/k8s:1.27.3
-        command: ["/bin/sh", "-c", "kubectl delete raycluster --all"]
+        command: ["/bin/sh", "-c", "kubectl delete raycluster -l nodelete=true"]

--- a/infrastructure/helm/quantum-serverless/templates/predelete.yaml
+++ b/infrastructure/helm/quantum-serverless/templates/predelete.yaml
@@ -22,6 +22,6 @@ spec:
       restartPolicy: Never
       serviceAccountName: gateway
       containers:
-      - name: pre-install-job
+      - name: delete-orphan-rayclusters-job
         image: alpine/k8s:1.27.3
         command: ["/bin/sh", "-c", "kubectl delete raycluster --all"]

--- a/infrastructure/helm/quantum-serverless/templates/predelete.yaml
+++ b/infrastructure/helm/quantum-serverless/templates/predelete.yaml
@@ -24,4 +24,4 @@ spec:
       containers:
       - name: pre-install-job
         image: alpine/k8s:1.27.3
-        command: ["/bin/sh", "-c", "kubectl delete raycluster -l nodelete=true"]
+        command: ["/bin/sh", "-c", "kubectl delete raycluster --all"]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
fix: #695 


### Details and comments
Add pre-delete hook that deletes all remaining raycluster instances at helm uninstall.
