### PR TITLE
Change the labels of scheduler deployment and pod

### DIFF
--- a/infrastructure/helm/quantumserverless/charts/gateway/templates/_helpers.tpl
+++ b/infrastructure/helm/quantumserverless/charts/gateway/templates/_helpers.tpl
@@ -41,12 +41,25 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
+{{- define "scheduler.labels" -}}
+helm.sh/chart: {{ include "gateway.chart" . }}
+{{ include "scheduler.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
 
 {{/*
 Selector labels
 */}}
 {{- define "gateway.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+gateway: "true"
+{{- end }}
+{{- define "scheduler.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gateway.name" . }}-scheduler
 app.kubernetes.io/instance: {{ .Release.Name }}
 gateway: "true"
 {{- end }}

--- a/infrastructure/helm/quantumserverless/charts/gateway/templates/deployment.yaml
+++ b/infrastructure/helm/quantumserverless/charts/gateway/templates/deployment.yaml
@@ -122,14 +122,14 @@ kind: Deployment
 metadata:
   name: scheduler
   labels:
-    {{- include "gateway.labels" . | nindent 4 }}-scheduler
+    {{- include "scheduler.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: 1
   {{- end }}
   selector:
     matchLabels:
-      {{- include "gateway.selectorLabels" . | nindent 6 }}
+      {{- include "scheduler.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -137,7 +137,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "gateway.selectorLabels" . | nindent 8 }}
+        {{- include "scheduler.selectorLabels" . | nindent 8 }}
     spec:
       volumes:
         - name: gateway-pv-storage


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
fix #701 

Create an unique labels for scheduler deployment and pod

### Details and comments
The scheduler deployment and pod are using the same labels as the gateway.  It causes the gateway service attached to both the gateway and scheduler pods.  The gateway service should only be attached to the gateway pods.

