### PR TITLE
helm install doc change

### DIFF
--- a/docs/deployment/cloud.rst
+++ b/docs/deployment/cloud.rst
@@ -100,18 +100,13 @@ In this step your only requirement is to have a *k8s cluster* available. You hav
     * `Amazon EKS cluster <https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html>`_
     * `Azure AKS cluster <https://learn.microsoft.com/en-us/azure/aks/tutorial-kubernetes-deploy-cluster?tabs=azure-cli>`_
 
-Once your cluster is ready, the installation is relatively straightforward with Helm. You just need to access to your cluster
+Once your cluster is ready, the installation is relatively straightforward with Helm. To install a released version, You just need to access to your cluster
 and run the next commands:
 
 .. code-block::
-   :caption: run these commands from ./infrastructure/helm/quantumserverless directory
+   :caption: run this commands with the release version like 0.2.0 in x.y.z (2 places)
 
-        $ helm repo add bitnami https://charts.bitnami.com/bitnami
-        $ helm repo add kuberay https://ray-project.github.io/kuberay-helm
-        $ helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-        $ helm repo add grafana https://grafana.github.io/helm-charts
-        $ helm dependency build
-        $ helm -n <INSERT_YOUR_NAMESPACE> install quantum-serverless --create-namespace .
+        $ helm -n <INSERT_YOUR_NAMESPACE> install quantum-serverless --create-namespace https://github.com/Qiskit-Extensions/quantum-serverless/releases/download/vx.y.z/quantum-serverless-x.y.z.tgz
 
 This will deploy the required components to your cluster.
 
@@ -119,21 +114,21 @@ To connect with the different services, you have some options depending on your 
 approach is to use the ``port-forward`` command:
 
 .. code-block::
-   :caption: get kuberay-head and jupyter pods
+   :caption: get gateway and jupyter pods
 
-        $ kubectl get pod -o wide
+        $ kubectl get service
         $ > ...
-        $ > jupyter-<POD_ID>
-        $ > kuberay-head-<POD_ID>
+        $ > jupyter ClusterIP 10.43.74.253 <none>   80/TCP
+        $ > gateway ClusterIP 10.43.86.146 <none> 8000/TCP
         $ > ...
 
-Now that we have the desired pods, we can expose their ports:
+Now that we have the desired services, we can expose their ports:
 
 .. code-block::
    :caption: ports 8265 and 8888 are the the default ports for each service
 
-        $  kubectl port-forward kuberay-head-<POD_ID> 8265
-        $  kubectl port-forward jupyter-<POD_ID> 8888
+        $  kubectl port-forward service/gateway  3333:8000
+        $  kubectl port-forward jupyter-<POD_ID> 4444:80
 
 Now you may access your cluster services from localhost.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Change the helm install instructions to install from the github release artifacts instead of the local clone of the repository.   It allows the user to install quantum middleware without cloning the repository and install any released version easily.

### Details and comments

This also change the example of the port forward from the pod IP to the service.  The service names are static so the user can always set port forward in the same way.
 

