### PR TITLE
add exception handling in kill_ray_cluster

### DIFF
--- a/gateway/api/ray.py
+++ b/gateway/api/ray.py
@@ -211,9 +211,7 @@ def kill_ray_cluster(cluster_name: str) -> bool:
             cluster_name,
         )
     try:
-        cert_client.delete(
-            name=f"{cluster_name}-worker", namespace=namespace
-        )
+        cert_client.delete(name=f"{cluster_name}-worker", namespace=namespace)
         success = True
     except NotFoundError:
         logging.error(
@@ -223,9 +221,7 @@ def kill_ray_cluster(cluster_name: str) -> bool:
 
     corev1 = client.CoreV1Api()
     try:
-        corev1.delete_namespaced_secret(
-            name=cluster_name, namespace=namespace
-        )
+        corev1.delete_namespaced_secret(name=cluster_name, namespace=namespace)
         success = True
     except ApiException:
         logging.error(

--- a/gateway/api/ray.py
+++ b/gateway/api/ray.py
@@ -203,67 +203,43 @@ def kill_ray_cluster(cluster_name: str) -> bool:
         return success
 
     try:
-        delete_response = cert_client.delete(name=cluster_name, namespace=namespace)
-        if delete_response.status == "Success":
-            success = True
-        else:
-            logging.error(
-                "Something went wrong during ray certification deletion request: %s",
-                delete_response.text,
-            )
+        cert_client.delete(name=cluster_name, namespace=namespace)
+        success = True
     except NotFoundError:
         logging.error(
             "Something went wrong during ray certification deletion request: %s",
-            delete_response.text,
+            cluster_name,
         )
     try:
-        delete_response = cert_client.delete(
+        cert_client.delete(
             name=f"{cluster_name}-worker", namespace=namespace
         )
-        if delete_response.status == "Success":
-            success = True
-        else:
-            logging.error(
-                "Something went wrong during ray certification deletion request: %s",
-                delete_response.text,
-            )
+        success = True
     except NotFoundError:
         logging.error(
             "Something went wrong during ray certification deletion request: %s",
-            delete_response.text,
+            f"{cluster_name}-worker",
         )
 
     corev1 = client.CoreV1Api()
     try:
-        delete_response = corev1.delete_namespaced_secret(
+        corev1.delete_namespaced_secret(
             name=cluster_name, namespace=namespace
         )
-        if delete_response.status == "Success":
-            success = True
-        else:
-            logging.error(
-                "Something went wrong during certification secret deletion request: %s",
-                delete_response,
-            )
+        success = True
     except ApiException:
         logging.error(
             "Something went wrong during ray secret deletion request: %s",
-            delete_response,
+            cluster_name,
         )
     try:
-        delete_response = corev1.delete_namespaced_secret(
+        corev1.delete_namespaced_secret(
             name=f"{cluster_name}-worker", namespace=namespace
         )
-        if delete_response.status == "Success":
-            success = True
-        else:
-            logging.error(
-                "Something went wrong during certification secret deletion request: %s",
-                delete_response,
-            )
+        success = True
     except ApiException:
         logging.error(
             "Something went wrong during ray secret deletion request: %s",
-            delete_response,
+            f"{cluster_name}-worker",
         )
     return success


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
fix #708 


### Details and comments

Add exception handling in kill_ray_cluster.
The request process sometimes finishes before the creation of the certificate or the secret for the certificate of the worker node.  So the deletion of them sometimes fails.  This add exception handling for the case. 