### PR TITLE
Configure security context for gateway

### DIFF
--- a/infrastructure/helm/quantumserverless/charts/gateway/values.yaml
+++ b/infrastructure/helm/quantumserverless/charts/gateway/values.yaml
@@ -58,9 +58,9 @@ serviceAccount:
 podAnnotations: {}
 
 podSecurityContext: 
+  fsGroup: 1000
   runAsUser: 1000
   runAsGroup: 100
-  fsGroup: 1000
 #  fsGroupChangePolicy: "OnRootMismatch"
 
 securityContext: {}

--- a/infrastructure/helm/quantumserverless/charts/gateway/values.yaml
+++ b/infrastructure/helm/quantumserverless/charts/gateway/values.yaml
@@ -57,10 +57,10 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
-#  fsGroup: 1001
-#  runAsUser: 1001
-#  runAsGroup: 1001
+podSecurityContext: 
+  runAsUser: 1000
+  runAsGroup: 100
+  fsGroup: 100
 #  fsGroupChangePolicy: "OnRootMismatch"
 
 securityContext: {}

--- a/infrastructure/helm/quantumserverless/charts/gateway/values.yaml
+++ b/infrastructure/helm/quantumserverless/charts/gateway/values.yaml
@@ -60,7 +60,7 @@ podAnnotations: {}
 podSecurityContext: 
   runAsUser: 1000
   runAsGroup: 100
-  fsGroup: 100
+  fsGroup: 1000
 #  fsGroupChangePolicy: "OnRootMismatch"
 
 securityContext: {}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

From our tests deploying the project with the new `pvc` structure we discovered that if we want use a`cos` with non-root access we need to configure the security context for the `pod` correctly.

This PR configures `gateway` chart with the user and group `1000:100` following the same configuration that we have in our Dockerfile. `fsGroup` and `runAsUser` with the same values.

### Details and comments

I decided to change these values internally and not through values because this configuration comes from the Dockerfile. Something that people will not be able to configure (easily at least).

- Info about PVC configuration for non-root users: https://cloud.ibm.com/docs/containers?topic=containers-storage-cos-understand
- Info about security context configuration: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
- Gateway's Dockerfile: https://github.com/Qiskit-Extensions/quantum-serverless/blob/main/infrastructure/docker/Dockerfile-gateway#L20
