### PR TITLE
Pin scipy to 1.10

### DIFF
--- a/infrastructure/docker/Dockerfile-notebook
+++ b/infrastructure/docker/Dockerfile-notebook
@@ -21,6 +21,7 @@ RUN pip install . --no-cache-dir &&\
     circuit-knitting-toolbox==0.2.0 \
     matplotlib==3.7.1 \
     pyscf==2.2.1 \
+    scipy==1.10 \
     qiskit-ibmq-provider==0.20.2 \
     qiskit-aer==0.12.0
 

--- a/infrastructure/docker/Dockerfile-notebook
+++ b/infrastructure/docker/Dockerfile-notebook
@@ -15,6 +15,7 @@ USER $NB_UID
 COPY --chown=$NB_UID:$NB_UID ./client ./qs
 
 WORKDIR /qs
+# TODO: scipy version pinned to 1.10, pyscf depends on. More info in #722
 RUN pip install . --no-cache-dir &&\
     pip install --no-cache-dir \
     ipywidgets==8.0.6 \

--- a/infrastructure/docker/Dockerfile-ray-qiskit
+++ b/infrastructure/docker/Dockerfile-ray-qiskit
@@ -29,7 +29,7 @@ COPY --chown=$RAY_UID:$RAY_UID ./client ./qs
 WORKDIR /qs
 RUN pip install . --no-cache-dir &&\
     if [ "$TARGETARCH" = "arm64" ] ; \
-        then pip install --no-cache-dir pyscf==2.2.1 scipy==1.10 \
+        then pip install --no-cache-dir pyscf==2.2.1 scipy==1.10 ; \
     fi
 
 WORKDIR /

--- a/infrastructure/docker/Dockerfile-ray-qiskit
+++ b/infrastructure/docker/Dockerfile-ray-qiskit
@@ -27,6 +27,7 @@ RUN apt-get -y update &&\
 COPY --chown=$RAY_UID:$RAY_UID ./client ./qs
 
 WORKDIR /qs
+# TODO: scipy version pinned to 1.10, pyscf depends on. More info in #722
 RUN pip install . --no-cache-dir &&\
     if [ "$TARGETARCH" = "arm64" ] ; \
         then pip install --no-cache-dir pyscf==2.2.1 scipy==1.10 ; \

--- a/infrastructure/docker/Dockerfile-ray-qiskit
+++ b/infrastructure/docker/Dockerfile-ray-qiskit
@@ -29,7 +29,7 @@ COPY --chown=$RAY_UID:$RAY_UID ./client ./qs
 WORKDIR /qs
 RUN pip install . --no-cache-dir &&\
     if [ "$TARGETARCH" = "arm64" ] ; \
-        then pip install --no-cache-dir git+https://github.com/pyscf/pyscf@v2.2.1 ; \ 
+        then pip --no-cache-dir pyscf==2.2.1 scipy==1.10 \
     fi
 
 WORKDIR /

--- a/infrastructure/docker/Dockerfile-ray-qiskit
+++ b/infrastructure/docker/Dockerfile-ray-qiskit
@@ -29,7 +29,7 @@ COPY --chown=$RAY_UID:$RAY_UID ./client ./qs
 WORKDIR /qs
 RUN pip install . --no-cache-dir &&\
     if [ "$TARGETARCH" = "arm64" ] ; \
-        then pip --no-cache-dir pyscf==2.2.1 scipy==1.10 \
+        then pip install --no-cache-dir pyscf==2.2.1 scipy==1.10 \
     fi
 
 WORKDIR /


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

From #721 we discovered a problem in the `scipy` package. Since version `1.11` argument `sym_pos` is removed so we need to pin version until `scipy` updates.
