### PR TITLE
Prepull ray images to all cluster nodes

### DIFF
--- a/infrastructure/helm/quantumserverless/templates/image-prepuller-daemonset.yaml
+++ b/infrastructure/helm/quantumserverless/templates/image-prepuller-daemonset.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepuller
+spec:
+  selector:
+    matchLabels:
+      name: prepuller
+  template:
+    metadata:
+      labels:
+        name: prepuller
+    spec:
+      initContainers:
+         - name: prepuller-1
+           image: {{ .Values.gateway.application.ray.nodeImage }}
+           command: ["sh", "-c", "'true'"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/infrastructure/helm/quantumserverless/templates/image-prepuller-daemonset.yaml
+++ b/infrastructure/helm/quantumserverless/templates/image-prepuller-daemonset.yaml
@@ -17,4 +17,4 @@ spec:
            command: ["sh", "-c", "'true'"]
       containers:
         - name: pause
-          image: gcr.io/google_containers/pause
+          image: gcr.io/google_containers/pause:3.2


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #728 
Add a daemonset to prepull the ray images to all nodes in the cluster.

### Details and comments

A [daemonset](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) ensures that all nodes run a copy of a pod. Our daemonset is set up using the ray node (using the value from the gateway ray image key) as an init container and the google "pause" container as the main one (the "pause" container more or less just sleeps and has minimal footprint). By using a daemonset, we ensure that anytime a new node is added to the cluster, the ray image will be pulled to it.