### PR TITLE
Add default annotation to scrape gateway

### DIFF
--- a/infrastructure/helm/quantumserverless/charts/gateway/values.yaml
+++ b/infrastructure/helm/quantumserverless/charts/gateway/values.yaml
@@ -55,7 +55,9 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podAnnotations: {}
+podAnnotations:
+  prometheus.io/scrape: "true"
+
 
 podSecurityContext: 
   fsGroup: 1000


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Adds an entry to `podAnnotations` for the gateway. 

### Details and comments

Annotation is `prometheus.io/scrape: "true"`. Needed to enable default scraping of the gateway pods by Prometheus, Sysdig, etc.