### PR TITLE
mount cert volumes to init container

### DIFF
--- a/infrastructure/helm/quantumserverless/charts/gateway/templates/rayclustertemplate.yaml
+++ b/infrastructure/helm/quantumserverless/charts/gateway/templates/rayclustertemplate.yaml
@@ -264,6 +264,11 @@ data:
               - mountPath: /data
                 name: user-storage
                 subPath: {{`{{ user_id }}`}}
+              - mountPath: /etc/ca/tls
+                name: ca-tls
+                readOnly: true
+              - mountPath: /etc/ray/tls
+                name: ray-tls
             imagePullSecrets: []
 {{- if .Values.useCertManager }}
             serviceAccountName: ray-cluster-sa


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
fix #776


### Details and comments
The init container needs the certificates to communicate to the head node.  The volume mounts were missing. 
