### PR TITLE
Configure ray pods for prometheus scraping

### DIFF
--- a/infrastructure/helm/quantumserverless/charts/gateway/templates/rayclustertemplate.yaml
+++ b/infrastructure/helm/quantumserverless/charts/gateway/templates/rayclustertemplate.yaml
@@ -10,16 +10,20 @@ data:
       name: {{`{{ cluster_name }}`}}
       namespace: {{ .Release.Namespace }}
     spec:
+{{- if .Values.application.ray.scrapeWithPrometheus }}      
       headServiceAnnotations:
-        prometheus.io/scrape: "true"    
+        prometheus.io/scrape: "true"
+{{- end }}        
       headGroupSpec:
         rayStartParams:
           dashboard-host: 0.0.0.0
         serviceType: ClusterIP
         template:
+{{- if .Values.application.ray.scrapeWithPrometheus }}                
           metadata:
             annotations:
-              prometheus.io/scrape: "true"    
+              prometheus.io/scrape: "true"
+{{- end }}              
           spec:
             initContainers:
               # Generate head's private key and certificate before `ray start`.
@@ -174,9 +178,11 @@ data:
           block: 'true'
         replicas: {{ .Values.application.ray.replicas }}
         template:
+{{- if .Values.application.ray.scrapeWithPrometheus }}      
           metadata:
             annotations:
-              prometheus.io/scrape: "true"              
+              prometheus.io/scrape: "true"
+{{- end }}              
           spec:
             initContainers:
               # Generate worker's private key and certificate before `ray start`.

--- a/infrastructure/helm/quantumserverless/charts/gateway/templates/rayclustertemplate.yaml
+++ b/infrastructure/helm/quantumserverless/charts/gateway/templates/rayclustertemplate.yaml
@@ -10,11 +10,16 @@ data:
       name: {{`{{ cluster_name }}`}}
       namespace: {{ .Release.Namespace }}
     spec:
+      headServiceAnnotations:
+        prometheus.io/scrape: "true"    
       headGroupSpec:
         rayStartParams:
           dashboard-host: 0.0.0.0
         serviceType: ClusterIP
         template:
+          metadata:
+            annotations:
+              prometheus.io/scrape: "true"    
           spec:
             initContainers:
               # Generate head's private key and certificate before `ray start`.
@@ -169,6 +174,9 @@ data:
           block: 'true'
         replicas: {{ .Values.application.ray.replicas }}
         template:
+          metadata:
+            annotations:
+              prometheus.io/scrape: "true"              
           spec:
             initContainers:
               # Generate worker's private key and certificate before `ray start`.

--- a/infrastructure/helm/quantumserverless/charts/gateway/values.yaml
+++ b/infrastructure/helm/quantumserverless/charts/gateway/values.yaml
@@ -26,6 +26,7 @@ application:
     maxReplicas: 4
     opensslImage: registry.access.redhat.com/ubi8/openssl:8.8-5
     kubectlImage: alpine/k8s:1.27.3
+    scrapeWithPrometheus: true
   limits:
     maxJobsPerUser: 2
     maxComputeResources: 4


### PR DESCRIPTION
Adds annotation so that ray pods / services will be scraped by Prometheus by default. Can be disabled in the gateway helm chart if so desired.

xref #775 