### PR TITLE
Added encoder/decoder to save_result() and result()

### DIFF
--- a/client/quantum_serverless/core/job.py
+++ b/client/quantum_serverless/core/job.py
@@ -52,7 +52,10 @@ from quantum_serverless.core.constants import (
 )
 from quantum_serverless.core.program import Program
 from quantum_serverless.exception import QuantumServerlessException
-from quantum_serverless.serializers.program_serializers import QiskitObjectsEncoder, QiskitObjectsDecoder
+from quantum_serverless.serializers.program_serializers import (
+    QiskitObjectsEncoder,
+    QiskitObjectsDecoder,
+)
 from quantum_serverless.utils.json import is_jsonable, safe_json_request
 
 RuntimeEnv = ray.runtime_env.RuntimeEnv
@@ -262,8 +265,9 @@ class GatewayJobClient(BaseJobClient):
                 timeout=REQUESTS_TIMEOUT,
             )
         )
-        return json.loads(response_data.get("result", "{}") or "{}", 
-                          cls=QiskitObjectsDecoder)
+        return json.loads(
+            response_data.get("result", "{}") or "{}", cls=QiskitObjectsDecoder
+        )
 
     def get(self, job_id) -> Optional["Job"]:
         url = f"{self.host}/api/{self.version}/jobs/{job_id}/"
@@ -386,8 +390,7 @@ def save_result(result: Dict[str, Any]):
     )
     response = requests.post(
         url,
-        data={
-            "result": json.dumps(result or {}, cls=QiskitObjectsEncoder)},
+        data={"result": json.dumps(result or {}, cls=QiskitObjectsEncoder)},
         headers={"Authorization": f"Bearer {token}"},
         timeout=REQUESTS_TIMEOUT,
     )

--- a/client/quantum_serverless/core/job.py
+++ b/client/quantum_serverless/core/job.py
@@ -52,7 +52,7 @@ from quantum_serverless.core.constants import (
 )
 from quantum_serverless.core.program import Program
 from quantum_serverless.exception import QuantumServerlessException
-from quantum_serverless.serializers.program_serializers import QiskitObjectsEncoder
+from quantum_serverless.serializers.program_serializers import QiskitObjectsEncoder, QiskitObjectsDecoder
 from quantum_serverless.utils.json import is_jsonable, safe_json_request
 
 RuntimeEnv = ray.runtime_env.RuntimeEnv
@@ -262,7 +262,8 @@ class GatewayJobClient(BaseJobClient):
                 timeout=REQUESTS_TIMEOUT,
             )
         )
-        return json.loads(response_data.get("result", "{}") or "{}")
+        return json.loads(response_data.get("result", "{}") or "{}", 
+                          cls=QiskitObjectsDecoder)
 
     def get(self, job_id) -> Optional["Job"]:
         url = f"{self.host}/api/{self.version}/jobs/{job_id}/"
@@ -385,7 +386,8 @@ def save_result(result: Dict[str, Any]):
     )
     response = requests.post(
         url,
-        json={"result": result},
+        data={
+            "result": json.dumps(result or {}, cls=QiskitObjectsEncoder)},
         headers={"Authorization": f"Bearer {token}"},
         timeout=REQUESTS_TIMEOUT,
     )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes. - Existing tests cover this issue.
- [ ] I have updated the documentation accordingly. - I don't believe there will be any documentation updates needed.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
save_result() and result() now support all types that 'Program.arguments' supports.


### Details and comments
I added QiskitObjectsDecoder to result(). I also changed save_result() to use data rather than json in the response, and then used json.dumps to still get the intended json. I did this so I could also use QiskitObjectsEncoder here.

