### PR TITLE
Switch to Qiskit Ecosystem theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,8 @@ add_module_names = False
 modindex_common_prefix = ["quantum_serverless_project."]
 
 # html theme options
-html_theme = "qiskit"
+html_theme = "qiskit-ecosystem"
+html_title = f"{project} {release}"
 
 # autodoc/autosummary options
 autosummary_generate = True

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -17,7 +17,7 @@ ray==2.5.0
 qiskit-terra==0.21.1
 qiskit-ibm-runtime==0.7.0rc2
 sphinx-copybutton>=0.5.2
-qiskit-sphinx-theme~=1.13.1
+qiskit-sphinx-theme~=1.14.0rc1
 redis>=4.3.4
 # opentelemetry
 opentelemetry-api>=1.15.0


### PR DESCRIPTION
The main changes are:

1. Gets rid of the top Qiskit nav bar.
2. Adds the project name and Qiskit Ecosystem logo to the left sidebar. (You can disable the logo or replace it with your own)