### PR TITLE
fix qiskit-terra to 0.24.1 for now

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,7 +1,7 @@
 ray[default,data]>=2.5.0, <3
 requests>=2.31.0
 importlib-metadata>=5.2.0
-qiskit-terra>=0.24.1
+qiskit-terra==0.24.1
 qiskit-ibm-runtime>=0.10.0
 redis>=4.5.5
 # opentelemetry


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fix #803 


### Details and comments
`qiskit_terra-0.24.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl` is missing in the qiskit-terra [Download files](https://pypi.org/project/qiskit-terra/0.24.2/#files).
`qiskit_terra-0.24.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl` exists [here](https://pypi.org/project/qiskit-terra/0.24.1/#files)
