### PR TITLE
Hook into version number in metadata when building docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,9 +16,10 @@ author = ""
 _rootdir = Path(__file__).parent.parent
 
 # The full version, including alpha/beta/rc tags
-release = "0.0.0"
+release = metadata_version("quantum_serverless")
+
 # The short X.Y version
-version = "0.0"
+version = ".".join(release.split(".")[:3])
 
 extensions = [
     "sphinx.ext.napoleon",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ _rootdir = Path(__file__).parent.parent
 # The full version, including alpha/beta/rc tags
 release = metadata_version("quantum_serverless")
 
-# The short X.Y version
+# The X.Y.Z version
 version = ".".join(release.split(".")[:3])
 
 extensions = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,7 @@ Sphinx documentation builder
 import os
 import sys
 from pathlib import Path
+from importlib.metadata import version as metadata_version
 
 sys.path.append(os.path.abspath('../client'))
 

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -1,3 +1,4 @@
+quantum-serverless>=0.0.7
 coverage>=5.5
 pylint>=2.17.4
 nbqa>=1.7.0
@@ -13,14 +14,5 @@ reno>=3.5.0
 # Black's formatting rules can change between major versions, so we use
 # the ~= specifier for it.
 black[jupyter]~=22.12
-ray==2.5.0
-qiskit-terra==0.21.1
-qiskit-ibm-runtime==0.7.0rc2
 sphinx-copybutton>=0.5.2
 qiskit-sphinx-theme~=1.14.0rc1
-redis>=4.3.4
-# opentelemetry
-opentelemetry-api>=1.15.0
-opentelemetry-sdk>=1.15.0
-opentelemetry-exporter-otlp-proto-grpc>=1.15.0
-s3fs>=2023.5.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
The docs are incorrectly displaying Quantum Serverless v0.0.0 in the upper-left corner.

This PR causes the docs to hook into the version listed in the package metadata when being built, preventing these from going out of sync in the future.


### Details and comments

We need to install quantum-serverless in the docs build now, but we can simplify the requirements-docs.txt quite a bit by doing that at least.

