### PR TITLE
Add token to quickstart

### DIFF
--- a/docs/quickstart/index.rst
+++ b/docs/quickstart/index.rst
@@ -56,7 +56,7 @@ Step 4: Run infrastructure.
       cd quantum-serverless/
       docker compose --profile jupyter up
 
-Step 5: Open the jupyter lab environment by going to ``localhost:8888`` via your favorite browser.
+Step 5: Open the jupyter lab environment by going to ``localhost:8888``. The default token is ``123``.
 
 Step 6: Write your program in containerized environment.
 


### PR DESCRIPTION
There has been confusion on how to get into the local jupyter environment when following the Quickstart guide due to the token not being provided. This PR tells the user what the default token is.
