### PR TITLE
pin redis to 4.x

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -3,7 +3,7 @@ requests>=2.31.0
 importlib-metadata>=5.2.0
 qiskit-terra==0.24.1
 qiskit-ibm-runtime>=0.11.2
-redis==4.6.0
+redis>=4.6.0, <5.0
 # opentelemetry
 opentelemetry-api>=1.18.0
 opentelemetry-sdk>=1.18.0

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -3,7 +3,7 @@ requests>=2.31.0
 importlib-metadata>=5.2.0
 qiskit-terra==0.24.1
 qiskit-ibm-runtime>=0.11.2
-redis>=4.6.0
+redis==4.6.0
 # opentelemetry
 opentelemetry-api>=1.18.0
 opentelemetry-sdk>=1.18.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Pin Redis to 4.x for now.

Client verify fails with redis 5.0.0 


### Details and comments

