### PR TITLE
Relax Qiskit version constraint

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,7 +1,7 @@
 ray[default,data]>=2.6.2, <3
 requests>=2.31.0
 importlib-metadata>=5.2.0
-qiskit-terra==0.25.0
+qiskit>=0.44.0
 qiskit-ibm-runtime>=0.11.3
 redis>=4.6.0, <5.0
 # opentelemetry


### PR DESCRIPTION
Let's unpin the Qiskit version from the client, so it can be used more flexibly.

May as well update to the new `qiskit` namespace while we're at it, I guess.
