### PR TITLE
Pin django-allauth to 0.54

### DIFF
--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -1,7 +1,7 @@
 django-filter>=23.2
 djangorestframework>=3.14.0
 Markdown>=3.4.4
-django-allauth>=0.54.0
+django-allauth==0.54.0
 django-allow-cidr>=0.7.1
 dj-rest-auth>=3.0.0
 djangorestframework-simplejwt>=5.2.2


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Last day `django-allauth` released version `0.55` with an incompatibility change that it's not being supported by `dj-rest-auth`.

### Details and comments
- Changelog from `django-allauth`: https://github.com/pennersr/django-allauth/blob/main/ChangeLog.rst#backwards-incompatible-changes
- Issue related with this error: https://github.com/iMerica/dj-rest-auth/issues/534
