### PR TITLE
pin dj-rest-auth to 4.0.1

### DIFF
--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -3,7 +3,7 @@ djangorestframework>=3.14.0
 Markdown>=3.4.4
 django-allauth==0.54.0
 django-allow-cidr>=0.7.1
-dj-rest-auth>=3.0.0
+dj-rest-auth==4.0.1
 djangorestframework-simplejwt>=5.2.2
 django_prometheus>=2.3.1
 ray[default]>=2.6.3


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

dj-rest-auth 5.0.0 was released today.  It causes an error at getting token.

### Details and comments

Here is the log of the gateway pod.  
```
ERROR 2023-09-12 00:12:18,829 log.py:241 : Internal Server Error: /dj-rest-auth/keycloak/
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.9/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.9/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
    return view_func(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/django/views/generic/base.py", line 104, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/django/utils/decorators.py", line 46, in _wrapper
    return bound_method(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/django/views/decorators/debug.py", line 92, in sensitive_post_parameters_wrapper
    return view(request, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/dj_rest_auth/views.py", line 48, in dispatch
    return super().dispatch(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
  File "/usr/local/lib/python3.9/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/usr/local/lib/python3.9/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/usr/local/lib/python3.9/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/dj_rest_auth/views.py", line 125, in post
    self.serializer.is_valid(raise_exception=True)
  File "/usr/local/lib/python3.9/site-packages/rest_framework/serializers.py", line 227, in is_valid
    self._validated_data = self.run_validation(self.initial_data)
  File "/usr/local/lib/python3.9/site-packages/rest_framework/serializers.py", line 429, in run_validation
    value = self.validate(value)
  File "/usr/local/lib/python3.9/site-packages/dj_rest_auth/registration/serializers.py", line 94, in validate
    app = adapter.get_provider().app
AttributeError: 'KeycloakProvider' object has no attribute 'app'
```
