### PR TITLE
Change Provider class name to ServerlessProvider

### DIFF
--- a/client/quantum_serverless/__init__.py
+++ b/client/quantum_serverless/__init__.py
@@ -30,7 +30,7 @@ from .core import (
     get,
     put,
     get_refs_by_status,
-    Provider,
+    ServerlessProvider,
     IBMServerlessProvider,
     save_result,
 )

--- a/client/quantum_serverless/__init__.py
+++ b/client/quantum_serverless/__init__.py
@@ -30,6 +30,7 @@ from .core import (
     get,
     put,
     get_refs_by_status,
+    Provider,
     ServerlessProvider,
     IBMServerlessProvider,
     save_result,

--- a/client/quantum_serverless/core/__init__.py
+++ b/client/quantum_serverless/core/__init__.py
@@ -26,6 +26,7 @@ Core abstractions
 .. autosummary::
     :toctree: ../stubs/
 
+    Provider
     ServerlessProvider
     IBMServerlessProvider
     BaseProvider
@@ -53,6 +54,7 @@ Core abstractions
 from .provider import (
     BaseProvider,
     ComputeResource,
+    Provider,
     ServerlessProvider,
     IBMServerlessProvider,
 )

--- a/client/quantum_serverless/core/__init__.py
+++ b/client/quantum_serverless/core/__init__.py
@@ -26,7 +26,7 @@ Core abstractions
 .. autosummary::
     :toctree: ../stubs/
 
-    Provider
+    ServerlessProvider
     IBMServerlessProvider
     BaseProvider
     ComputeResource
@@ -50,7 +50,7 @@ Core abstractions
 
 """
 
-from .provider import BaseProvider, ComputeResource, Provider, IBMServerlessProvider
+from .provider import BaseProvider, ComputeResource, ServerlessProvider, IBMServerlessProvider
 from .job import BaseJobClient, RayJobClient, GatewayJobClient, Job, save_result
 from .program import (
     Program,

--- a/client/quantum_serverless/core/__init__.py
+++ b/client/quantum_serverless/core/__init__.py
@@ -50,7 +50,12 @@ Core abstractions
 
 """
 
-from .provider import BaseProvider, ComputeResource, ServerlessProvider, IBMServerlessProvider
+from .provider import (
+    BaseProvider,
+    ComputeResource,
+    ServerlessProvider,
+    IBMServerlessProvider,
+)
 from .job import BaseJobClient, RayJobClient, GatewayJobClient, Job, save_result
 from .program import (
     Program,

--- a/client/quantum_serverless/core/decorators.py
+++ b/client/quantum_serverless/core/decorators.py
@@ -340,7 +340,7 @@ def distribute_program(
     """[Experimental] Program decorator to turn function into remotely executable program.
 
     Example:
-        >>> @distribute_program(provider=Provider(...), dependencies=[...])
+        >>> @distribute_program(provider=ServerlessProvider(...), dependencies=[...])
         >>> def my_program():
         >>>     print("Hola!")
         >>>
@@ -357,13 +357,13 @@ def distribute_program(
     # pylint: disable=import-outside-toplevel,cyclic-import
     from quantum_serverless import QuantumServerlessException
     from quantum_serverless.core.program import Program
-    from quantum_serverless.core.provider import Provider
+    from quantum_serverless.core.provider import ServerlessProvider
 
     # create provider
     if provider is None:
         # try to create from env vars
         try:
-            provider = Provider()
+            provider = ServerlessProvider()
         except QuantumServerlessException as qs_error:
             raise QuantumServerlessException(
                 "Set provider in arguments for `distribute_program` "

--- a/client/quantum_serverless/core/provider.py
+++ b/client/quantum_serverless/core/provider.py
@@ -320,6 +320,7 @@ class ServerlessProvider(BaseProvider):
         password: password
         token: authorization token
     """
+
     def __init__(
         self,
         name: Optional[str] = None,
@@ -362,13 +363,19 @@ class ServerlessProvider(BaseProvider):
         self._files_client = GatewayFilesClient(self.host, self._token, self.version)
 
     def get_compute_resources(self) -> List[ComputeResource]:
-        raise NotImplementedError(f"GatewayProvider does not support resources api yet.")
+        raise NotImplementedError(
+            f"GatewayProvider does not support resources api yet."
+        )
 
     def create_compute_resource(self, resource) -> int:
-        raise NotImplementedError(f"GatewayProvider does not support resources api yet.")
+        raise NotImplementedError(
+            f"GatewayProvider does not support resources api yet."
+        )
 
     def delete_compute_resource(self, resource) -> int:
-        raise NotImplementedError(f"GatewayProvider does not support resources api yet.")
+        raise NotImplementedError(
+            f"GatewayProvider does not support resources api yet."
+        )
 
     def get_job_by_id(self, job_id: str) -> Optional[Job]:
         return self._job_client.get(job_id)
@@ -428,6 +435,7 @@ class IBMServerlessProvider(ServerlessProvider):
     Args:
         token: IBM quantum token
     """
+
     def __init__(self, token: str):
         super().__init__(token=token, host=IBM_SERVERLESS_HOST_URL)
 

--- a/client/quantum_serverless/core/provider.py
+++ b/client/quantum_serverless/core/provider.py
@@ -363,19 +363,13 @@ class ServerlessProvider(BaseProvider):
         self._files_client = GatewayFilesClient(self.host, self._token, self.version)
 
     def get_compute_resources(self) -> List[ComputeResource]:
-        raise NotImplementedError(
-            f"GatewayProvider does not support resources api yet."
-        )
+        raise NotImplementedError("GatewayProvider does not support resources api yet.")
 
     def create_compute_resource(self, resource) -> int:
-        raise NotImplementedError(
-            f"GatewayProvider does not support resources api yet."
-        )
+        raise NotImplementedError("GatewayProvider does not support resources api yet.")
 
     def delete_compute_resource(self, resource) -> int:
-        raise NotImplementedError(
-            f"GatewayProvider does not support resources api yet."
-        )
+        raise NotImplementedError("GatewayProvider does not support resources api yet.")
 
     def get_job_by_id(self, job_id: str) -> Optional[Job]:
         return self._job_client.get(job_id)

--- a/client/quantum_serverless/core/provider.py
+++ b/client/quantum_serverless/core/provider.py
@@ -27,6 +27,7 @@ Quantum serverless provider
     ServerlessProvider
 """
 import logging
+import warnings
 import os.path
 from dataclasses import dataclass
 from typing import Optional, List, Dict, Any
@@ -312,21 +313,6 @@ class BaseProvider(JsonSerializable):
         return Widget(self).show()
 
 
-class Provider(ServerlessProvider):
-    """
-    [Deprecated since version 0.6.4] Use :class:`.ServerlessProvider` instead.
-
-    A provider for connecting to a specified host. This class has been
-    renamed to :class:`.ServerlessProvider`.
-    """
-
-    def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "The Provider class is deprecated. Use the identical ServerlessProvider class instead."
-        )
-        super.__init__(*args, **kwargs)
-
-
 class ServerlessProvider(BaseProvider):
     """
     A provider for connecting to a specified host.
@@ -448,6 +434,21 @@ class ServerlessProvider(BaseProvider):
             )
         except QuantumServerlessException as reason:
             raise QuantumServerlessException("Cannot verify token.") from reason
+
+
+class Provider(ServerlessProvider):
+    """
+    [Deprecated since version 0.6.4] Use :class:`.ServerlessProvider` instead.
+
+    A provider for connecting to a specified host. This class has been
+    renamed to :class:`.ServerlessProvider`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "The Provider class is deprecated. Use the identical ServerlessProvider class instead."
+        )
+        super().__init__(*args, **kwargs)
 
 
 class IBMServerlessProvider(ServerlessProvider):

--- a/client/quantum_serverless/core/provider.py
+++ b/client/quantum_serverless/core/provider.py
@@ -151,7 +151,7 @@ class BaseProvider(JsonSerializable):
     A provider class for specifying custom compute resources.
 
     Example:
-        >>> provider = ServerlessProvider(
+        >>> provider = BaseProvider(
         >>>    name="<NAME>",
         >>>    host="<HOST>",
         >>>    token="<TOKEN>",

--- a/client/quantum_serverless/core/provider.py
+++ b/client/quantum_serverless/core/provider.py
@@ -30,7 +30,6 @@ import logging
 import os.path
 from dataclasses import dataclass
 from typing import Optional, List, Dict, Any
-from abc import ABC, abstractmethod
 
 import ray
 import requests
@@ -147,16 +146,20 @@ class ComputeResource:
         return f"<ComputeResource: {self.name}>"
 
 
-class BaseProvider(ABC, JsonSerializable):
+class BaseProvider(JsonSerializable):
     """
-    Abstract base class for Quantum Serverless providers.
+    A provider class for specifying custom compute resources.
 
-    Args:
-        name: name of provider
-        host: host of provider a.k.a managers host
-        token: authentication token for manager
-        compute_resource: selected compute_resource from provider
-        available_compute_resources: available clusters in provider
+    Example:
+        >>> provider = ServerlessProvider(
+        >>>    name="<NAME>",
+        >>>    host="<HOST>",
+        >>>    token="<TOKEN>",
+        >>>    compute_resource=ComputeResource(
+        >>>        name="<COMPUTE_RESOURCE_NAME>",
+        >>>        host="<COMPUTE_RESOURCE_HOST>"
+        >>>    ),
+        >>> )
     """
 
     def __init__(
@@ -167,6 +170,16 @@ class BaseProvider(ABC, JsonSerializable):
         compute_resource: Optional[ComputeResource] = None,
         available_compute_resources: Optional[List[ComputeResource]] = None,
     ):
+        """
+        Initialize a BaseProvider instance.
+
+        Args:
+            name: name of provider
+            host: host of provider a.k.a managers host
+            token: authentication token for manager
+            compute_resource: selected compute_resource from provider
+            available_compute_resources: available clusters in provider
+        """
         self.name = name
         self.host = host
         self.token = token
@@ -207,29 +220,25 @@ class BaseProvider(ABC, JsonSerializable):
     def __repr__(self):
         return f"<Provider: {self.name}>"
 
-    @abstractmethod
     def get_compute_resources(self) -> List[ComputeResource]:
         """Return compute resources for provider."""
-        pass
+        raise NotImplementedError
 
-    @abstractmethod
     def create_compute_resource(self, resource) -> int:
         """Create compute resource for provider."""
-        pass
+        raise NotImplementedError
 
-    @abstractmethod
     def delete_compute_resource(self, resource) -> int:
         """Delete compute resource for provider."""
-        pass
+        raise NotImplementedError
 
-    @abstractmethod
     def get_jobs(self, **kwargs) -> List[Job]:
         """Return list of jobs.
 
         Returns:
             list of jobs.
         """
-        pass
+        raise NotImplementedError
 
     def get_job_by_id(self, job_id: str) -> Optional[Job]:
         """Returns job by job id.
@@ -282,26 +291,21 @@ class BaseProvider(ABC, JsonSerializable):
 
         return job_client.run(program, arguments)
 
-    @abstractmethod
     def files(self) -> List[str]:
         """Returns list of available files produced by programs to download."""
+        raise NotImplementedError
 
-    pass
-
-    @abstractmethod
     def download(self, file: str, download_location: str):
         """Download file."""
-        pass
+        raise NotImplementedError
 
-    @abstractmethod
     def delete(self, file: str):
         """Deletes file uploaded or produced by the programs,"""
-        pass
+        raise NotImplementedError
 
-    @abstractmethod
     def upload(self, file: str):
         """Upload file."""
-        pass
+        raise NotImplementedError
 
     def widget(self):
         """Widget for information about provider and jobs."""
@@ -310,17 +314,13 @@ class BaseProvider(ABC, JsonSerializable):
 
 class ServerlessProvider(BaseProvider):
     """
-    A provider class for connecting to any specified host.
+    A provider for connecting to a specified host.
 
     Example:
         >>> provider = ServerlessProvider(
         >>>    name="<NAME>",
         >>>    host="<HOST>",
         >>>    token="<TOKEN>",
-        >>>    compute_resource=ComputeResource(
-        >>>        name="<COMPUTE_RESOURCE_NAME>",
-        >>>        host="<COMPUTE_RESOURCE_HOST>"
-        >>>    ),
         >>> )
     """
 

--- a/client/quantum_serverless/core/provider.py
+++ b/client/quantum_serverless/core/provider.py
@@ -312,6 +312,21 @@ class BaseProvider(JsonSerializable):
         return Widget(self).show()
 
 
+class Provider(ServerlessProvider):
+    """
+    [Deprecated since version 0.6.4] Use :class:`.ServerlessProvider` instead.
+
+    A provider for connecting to a specified host. This class has been
+    renamed to :class:`.ServerlessProvider`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "The Provider class is deprecated. Use the identical ServerlessProvider class instead."
+        )
+        super.__init__(*args, **kwargs)
+
+
 class ServerlessProvider(BaseProvider):
     """
     A provider for connecting to a specified host.

--- a/client/quantum_serverless/quantum_serverless.py
+++ b/client/quantum_serverless/quantum_serverless.py
@@ -42,7 +42,10 @@ from opentelemetry.instrumentation.requests import RequestsInstrumentor
 
 from quantum_serverless.core.job import Job
 from quantum_serverless.core.program import Program
-from quantum_serverless.core.provider import BaseProvider, ComputeResource
+from quantum_serverless.core.provider import (
+    BaseProvider,
+    ComputeResource,
+)
 from quantum_serverless.exception import QuantumServerlessException
 
 Context = Union[BaseContext]

--- a/client/quantum_serverless/quantum_serverless.py
+++ b/client/quantum_serverless/quantum_serverless.py
@@ -42,10 +42,7 @@ from opentelemetry.instrumentation.requests import RequestsInstrumentor
 
 from quantum_serverless.core.job import Job
 from quantum_serverless.core.program import Program
-from quantum_serverless.core.provider import (
-    BaseProvider,
-    ComputeResource,
-)
+from quantum_serverless.core.provider import BaseProvider, ComputeResource
 from quantum_serverless.exception import QuantumServerlessException
 
 Context = Union[BaseContext]

--- a/docs/deployment/client_configuration.rst
+++ b/docs/deployment/client_configuration.rst
@@ -15,7 +15,7 @@ To install the client library, run:
 
 
 Next, we need to configure the client to communicate with the provider.
-This is done through the `Provider` configuration.
+This is done through the `ServerlessProvider` configuration.
 
 Before we can configure the client and provider,
 we need to know two things: the `username/password`
@@ -33,9 +33,9 @@ you can start configuring the client:
 
 .. code-block::
 
-		from quantum_serverless import QuantumServerless, Provider
+		from quantum_serverless import QuantumServerless, ServerlessProvider
 
-		provider = Provider(
+		provider = ServerlessProvider(
 			username="<USERNAME>",
 			password="<PASSWORD>",
 			host="<HOST>",

--- a/docs/deployment/client_configuration.rst
+++ b/docs/deployment/client_configuration.rst
@@ -15,7 +15,7 @@ To install the client library, run:
 
 
 Next, we need to configure the client to communicate with the provider.
-This is done through the `ServerlessProvider` configuration.
+This can be done through the `BaseProvider` configuration.
 
 Before we can configure the client and provider,
 we need to know two things: the `username/password`

--- a/docs/examples/01_vqe.ipynb
+++ b/docs/examples/01_vqe.ipynb
@@ -179,7 +179,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from quantum_serverless import QuantumServerless, Provider\n",
+    "from quantum_serverless import QuantumServerless, ServerlessProvider\n",
     "import os"
    ]
   },
@@ -189,7 +189,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "provider = Provider(\n",
+    "provider = ServerlessProvider(\n",
     "    username=os.environ.get(\"GATEWAY_USER\", \"user\"),\n",
     "    password=os.environ.get(\"GATEWAY_PASSWORD\", \"password123\"),\n",
     "    # token=os.environ.get(\"GATEWAY_TOKEN\", \"<TOKEN>\"), # token can be used instead of user/password combination\n",

--- a/docs/examples/02_qaoa.ipynb
+++ b/docs/examples/02_qaoa.ipynb
@@ -200,7 +200,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from quantum_serverless import QuantumServerless, Provider\n",
+    "from quantum_serverless import QuantumServerless, ServerlessProvider\n",
     "import os"
    ]
   },
@@ -221,7 +221,7 @@
     }
    ],
    "source": [
-    "provider = Provider(\n",
+    "provider = ServerlessProvider(\n",
     "    username=os.environ.get(\"GATEWAY_USER\", \"user\"),\n",
     "    password=os.environ.get(\"GATEWAY_PASSWORD\", \"password123\"),\n",
     "    # token=os.environ.get(\"GATEWAY_TOKEN\", \"<TOKEN>\"), # token can be used instead of user/password combination\n",

--- a/docs/getting_started/basic/01_running_program.ipynb
+++ b/docs/getting_started/basic/01_running_program.ipynb
@@ -46,7 +46,7 @@
     "\n",
     "To run the program, we need to import the necessary classes and configure them. One of these classes is QuantumServerless, which is a client class for interacting with compute resources.\n",
     "\n",
-    "QuantumServerless takes a Provider object as a constructor argument. The Provider object stores configuration information about our compute resources, such as where they are located and how to connect to them. In this example, we will use a provider that is connected to a local Docker Compose setup. In this case, it allows us to run the program locally on our machine. If you want to run the program elsewhere, you will need to provide the corresponding host and authentication details."
+    "QuantumServerless takes a [BaseProvider](https://qiskit-extensions.github.io/quantum-serverless/stubs/quantum_serverless.core.BaseProvider.html) instance as a constructor argument. The provider stores configuration information about our compute resources, such as where they are located and how to connect to them. In this example, we will use a provider that is connected to a local Docker Compose setup. In this case, it allows us to run the program locally on our machine. If you want to run the program elsewhere, you will need to provide the corresponding host and authentication details."
    ]
   },
   {
@@ -56,7 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from quantum_serverless import QuantumServerless, Provider\n",
+    "from quantum_serverless import QuantumServerless, ServerlessProvider\n",
     "import os"
    ]
   },
@@ -86,7 +86,7 @@
     }
    ],
    "source": [
-    "provider = Provider(\n",
+    "provider = ServerlessProvider(\n",
     "    username=os.environ.get(\"GATEWAY_USER\", \"user\"),\n",
     "    password=os.environ.get(\"GATEWAY_PASSWORD\", \"password123\"),\n",
     "    # token=os.environ.get(\"GATEWAY_TOKEN\", \"<TOKEN>\"), # token can be used instead of user/password combination\n",

--- a/docs/getting_started/basic/02_arguments_and_results.ipynb
+++ b/docs/getting_started/basic/02_arguments_and_results.ipynb
@@ -138,10 +138,10 @@
     }
    ],
    "source": [
-    "from quantum_serverless import QuantumServerless, Provider\n",
+    "from quantum_serverless import QuantumServerless, ServerlessProvider\n",
     "import os\n",
     "\n",
-    "provider = Provider(\n",
+    "provider = ServerlessProvider(\n",
     "    username=os.environ.get(\"GATEWAY_USER\", \"user\"),\n",
     "    password=os.environ.get(\"GATEWAY_PASSWORD\", \"password123\"),\n",
     "    # token=os.environ.get(\"GATEWAY_TOKEN\", \"<TOKEN>\"), # token can be used instead of user/password combination\n",

--- a/docs/getting_started/basic/03_dependencies.ipynb
+++ b/docs/getting_started/basic/03_dependencies.ipynb
@@ -104,10 +104,10 @@
     }
    ],
    "source": [
-    "from quantum_serverless import QuantumServerless, Provider\n",
+    "from quantum_serverless import QuantumServerless, ServerlessProvider\n",
     "import os\n",
     "\n",
-    "provider = Provider(\n",
+    "provider = ServerlessProvider(\n",
     "    username=os.environ.get(\"GATEWAY_USER\", \"user\"),\n",
     "    password=os.environ.get(\"GATEWAY_PASSWORD\", \"password123\"),\n",
     "    # token=os.environ.get(\"GATEWAY_TOKEN\", \"<TOKEN>\"), # token can be used instead of user/password combination\n",

--- a/docs/getting_started/basic/04_distributed_workloads.ipynb
+++ b/docs/getting_started/basic/04_distributed_workloads.ipynb
@@ -87,10 +87,10 @@
     }
    ],
    "source": [
-    "from quantum_serverless import QuantumServerless, Provider\n",
+    "from quantum_serverless import QuantumServerless, ServerlessProvider\n",
     "import os\n",
     "\n",
-    "provider = Provider(\n",
+    "provider = ServerlessProvider(\n",
     "    username=os.environ.get(\"GATEWAY_USER\", \"user\"),\n",
     "    password=os.environ.get(\"GATEWAY_PASSWORD\", \"password123\"),\n",
     "    # token=os.environ.get(\"GATEWAY_TOKEN\", \"<TOKEN>\"), # token can be used instead of user/password combination\n",

--- a/docs/getting_started/basic/05_retrieving_past_results.ipynb
+++ b/docs/getting_started/basic/05_retrieving_past_results.ipynb
@@ -15,7 +15,7 @@
    "id": "37322958-a029-46bb-bc46-82b7ded329b5",
    "metadata": {},
    "source": [
-    "First, create [Provider](https://qiskit-extensions.github.io/quantum-serverless/stubs/quantum_serverless.core.Provider.html#quantum_serverless.core.Provider) and [QuantumServerless](https://qiskit-extensions.github.io/quantum-serverless/stubs/quantum_serverless.QuantumServerless.html#quantum_serverless.QuantumServerless) instances.\n",
+    "First, create [ServerlessProvider](https://qiskit-extensions.github.io/quantum-serverless/stubs/quantum_serverless.core.Provider.html#quantum_serverless.core.ServerlessProvider) and [QuantumServerless](https://qiskit-extensions.github.io/quantum-serverless/stubs/quantum_serverless.QuantumServerless.html#quantum_serverless.QuantumServerless) instances.\n",
     "\n",
     "> &#x26A0; This provider is set up with default credentials to a test cluster intended to run on your machine. For information on setting up infrastructure on your local machine, check out the guide on [local infrastructure setup](https://qiskit-extensions.github.io/quantum-serverless/deployment/local.html)."
    ]
@@ -27,10 +27,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from quantum_serverless import QuantumServerless, Provider\n",
+    "from quantum_serverless import QuantumServerless, ServerlessProvider\n",
     "import os\n",
     "\n",
-    "provider = Provider(\n",
+    "provider = ServerlessProvider(\n",
     "    username=os.environ.get(\"GATEWAY_USER\", \"user\"),\n",
     "    password=os.environ.get(\"GATEWAY_PASSWORD\", \"password123\"),\n",
     "    # token=os.environ.get(\"GATEWAY_TOKEN\", \"<TOKEN>\"), # token can be used instead of user/password combination\n",

--- a/docs/getting_started/experimental/file_download.ipynb
+++ b/docs/getting_started/experimental/file_download.ipynb
@@ -48,9 +48,9 @@
    ],
    "source": [
     "import os\n",
-    "from quantum_serverless import QuantumServerless, Provider, Program\n",
+    "from quantum_serverless import QuantumServerless, ServerlessProvider, Program\n",
     "\n",
-    "provider = Provider(\n",
+    "provider = ServerlessProvider(\n",
     "    username=\"user\",\n",
     "    password=\"password123\",\n",
     "    host=os.environ.get(\"GATEWAY_HOST\", \"http://localhost:8000\"),\n",

--- a/docs/getting_started/experimental/running_programs_using_decorators.ipynb
+++ b/docs/getting_started/experimental/running_programs_using_decorators.ipynb
@@ -43,9 +43,9 @@
    ],
    "source": [
     "import os\n",
-    "from quantum_serverless import Provider\n",
+    "from quantum_serverless import ServerlessProvider\n",
     "\n",
-    "provider = Provider(\n",
+    "provider = ServerlessProvider(\n",
     "    username=\"user\",\n",
     "    password=\"password123\",\n",
     "    host=os.environ.get(\"GATEWAY_HOST\", \"http://localhost:8000\"),\n",
@@ -61,7 +61,7 @@
     "## Hello, Qiskit!\n",
     "\n",
     "Let's create simpliest program by writing a funtion `hello_qiskit` and annotating it with `@distribute_program` decorator. \n",
-    "Decorator accepts `Provider` as one of the arguments. Other arguments are `dependencies` to specify extra packages to install during execution and `working_dir` to specify working directory that will be shiped for remote execution if needed."
+    "The ``distribute_program`` decorator accepts a [BaseProvider](https://qiskit-extensions.github.io/quantum-serverless/stubs/quantum_serverless.core.BaseProvider.html) instance for the ``provider`` argument. Other arguments are `dependencies` to specify extra packages to install during execution and `working_dir` to specify working directory that will be shiped for remote execution if needed."
    ]
   },
   {

--- a/docs/migration/migration_from_qiskit_runtime_programs.ipynb
+++ b/docs/migration/migration_from_qiskit_runtime_programs.ipynb
@@ -126,10 +126,10 @@
     }
    ],
    "source": [
-    "from quantum_serverless import QuantumServerless, Provider\n",
+    "from quantum_serverless import QuantumServerless, ServerlessProvider\n",
     "import os\n",
     "\n",
-    "provider = Provider(\n",
+    "provider = ServerlessProvider(\n",
     "    username=os.environ.get(\"GATEWAY_USER\", \"user\"),\n",
     "    password=os.environ.get(\"GATEWAY_PASSWORD\", \"password123\"),\n",
     "    # token=os.environ.get(\"GATEWAY_TOKEN\", \"<TOKEN>\"), # token can be used instead of user/password combination\n",


### PR DESCRIPTION
Fixes #989 

In this PR, we rename ``Provider`` to ``ServerlessProvider``, and we use the new naming convention in all the notebooks in the docs. We also deprecate ``Provider``.