### PR TITLE
Add metadata to job client, including job runtime

### DIFF
--- a/gateway/api/migrations/0001_initial.py
+++ b/gateway/api/migrations/0001_initial.py
@@ -90,6 +90,7 @@ class Migration(migrations.Migration):
                 ),
                 ("created", models.DateTimeField(auto_now_add=True)),
                 ("result", models.TextField(blank=True, null=True)),
+                ("runtime", models.DurationField(null=True)),
                 (
                     "status",
                     models.CharField(

--- a/gateway/api/migrations/0001_initial.py
+++ b/gateway/api/migrations/0001_initial.py
@@ -90,7 +90,8 @@ class Migration(migrations.Migration):
                 ),
                 ("created", models.DateTimeField(auto_now_add=True)),
                 ("result", models.TextField(blank=True, null=True)),
-                ("runtime", models.DurationField(null=True)),
+                ("start_time", models.DateTimeField(null=True)),
+                ("end_time", models.DateTimeField(null=True)),
                 (
                     "status",
                     models.CharField(

--- a/gateway/api/models.py
+++ b/gateway/api/models.py
@@ -92,6 +92,7 @@ class Job(models.Model):
     arguments = models.TextField(null=False, blank=True, default="{}")
     env_vars = models.TextField(null=False, blank=True, default="{}")
     result = models.TextField(null=True, blank=True)
+    runtime = models.DurationField(null=True)
     author = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
@@ -108,7 +109,6 @@ class Job(models.Model):
     logs = models.TextField(default="No logs yet.")
 
     version = IntegerVersionField()
-    runtime = models.DurationField()
 
     def __str__(self):
         return f"<Job {self.pk} | {self.status}>"

--- a/gateway/api/models.py
+++ b/gateway/api/models.py
@@ -108,6 +108,7 @@ class Job(models.Model):
     logs = models.TextField(default="No logs yet.")
 
     version = IntegerVersionField()
+    runtime = models.DurationField()
 
     def __str__(self):
         return f"<Job {self.pk} | {self.status}>"

--- a/gateway/api/models.py
+++ b/gateway/api/models.py
@@ -92,7 +92,8 @@ class Job(models.Model):
     arguments = models.TextField(null=False, blank=True, default="{}")
     env_vars = models.TextField(null=False, blank=True, default="{}")
     result = models.TextField(null=True, blank=True)
-    runtime = models.DurationField(null=True)
+    start_time = models.DateTimeField(null=True)
+    end_time = models.DateTimeField(null=True)
     author = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,


### PR DESCRIPTION
Fixes #851 

This PR establishes a metadata field in the client job class. We will start by including the job runtime in the job model and using that field to populate a client job metadata field. We could continue adding items to the metadata in this way as needed

I think the correct way to do this is to expose the relevant fields in the job model (e.g. `Model.Job.runtime`) and add it to the client job as metadata (e.g. `QuantumServerless.core.Job.metadata['runtime'] = Model.Job.runtime`).