### PR TITLE
Add a qubits field to Target

### DIFF
--- a/client/quantum_serverless/core/decorators.py
+++ b/client/quantum_serverless/core/decorators.py
@@ -117,6 +117,7 @@ class Target(JsonSerializable):
     gpu: int = 0
     qpu: int = 0
     mem: int = 1
+    qubits: int = 0
     resources: Optional[Dict[str, float]] = None
     env_vars: Optional[Dict[str, Any]] = None
     pip: Optional[List[str]] = None
@@ -258,6 +259,7 @@ def _tracible_function(
 
 def distribute_task(
     target: Optional[Union[Dict[str, Any], Target]] = None,
+    selector: Optional[IBMQPUSelector] = None,
 ):
     """Wraps local function as remote executable function.
     New function will return reference object when called.


### PR DESCRIPTION
Fixes #1023 

We want to orchestrate at both the QPU _and_ qubit level, so let's add a field to the Target data class for users to request a certain number of qubits.
