### PR TITLE
Revert matplotlib version to 3.7.1

### DIFF
--- a/client/requirements-notebook.txt
+++ b/client/requirements-notebook.txt
@@ -1,8 +1,9 @@
 # TODO: certifi version pinned to 2023.7.22. More info in #870
 # TODO: ipython version pinned to 8.10.0. More info in #978
+# TODO: matplotlib version pinned to 3.7.1. More info in #1037
 ipywidgets==8.1.1
 circuit-knitting-toolbox==0.4.0
-matplotlib==3.8.0
+matplotlib==3.7.1
 qiskit-ibmq-provider==0.20.2
 qiskit-aer==0.12.0
 certifi==2023.7.22


### PR DESCRIPTION
### Summary

This should fix the problems we're seeing in #1037 , which is causing the release jobs to fail

### Details and comments

Reverts #1018
