### PR TITLE
Issue 1058 | Gateway: allow nested fields verification

### DIFF
--- a/gateway/api/authentication.py
+++ b/gateway/api/authentication.py
@@ -71,9 +71,16 @@ class CustomTokenBackend(authentication.BaseAuthentication):
                 )
 
                 if verification_data is not None:
-                    verified = verification_data.get(
-                        settings.SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD, False
-                    )
+                    verifications = []
+                    for (
+                        verification_field
+                    ) in settings.SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD.split(";"):
+                        nested_field_value = verification_data
+                        for nested_field in verification_field.split(","):
+                            nested_field_value = nested_field_value.get(nested_field)
+                        verifications.append(nested_field_value)
+
+                    verified = all(verifications)
 
                     if user_id is not None and verified:
                         try:

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -272,7 +272,18 @@ SETTINGS_TOKEN_AUTH_VERIFICATION_URL = os.environ.get(
 )
 # verification fields to check when returned from auth api
 # Example of checking multiple fields:
-#   "SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD", "is_valid;some,nested,field"
+#    For following verification data
+#    {
+#       "is_valid": true,
+#       "some": {
+#         "nested": {
+#           "field": true
+#         },
+#         "other": "bla"
+#       }
+#    }
+#   setting string will be:
+#    "SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD", "is_valid;some,nested,field"
 SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD = os.environ.get(
     "SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD", None
 )

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -270,6 +270,9 @@ SETTINGS_TOKEN_AUTH_TOKEN_FIELD = os.environ.get(
 SETTINGS_TOKEN_AUTH_VERIFICATION_URL = os.environ.get(
     "SETTINGS_TOKEN_AUTH_VERIFICATION_URL", None
 )
+# verification fields to check when returned from auth api
+# Example of checking multiple fields:
+#   "SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD", "is_valid;some,nested,field"
 SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD = os.environ.get(
     "SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD", None
 )

--- a/gateway/tests/api/test_authentication.py
+++ b/gateway/tests/api/test_authentication.py
@@ -43,3 +43,66 @@ class TestAuthentication(APITestCase):
             self.assertEqual(token.token, b"AWESOME_TOKEN")
 
             self.assertEqual(user.username, "AwesomeUser")
+
+    @responses.activate
+    def test_with_nested_verification_fields(self):
+        """Tests custom token auth."""
+        responses.add(
+            responses.POST,
+            "http://token_auth_url",
+            json={"userId": "AwesomeUser", "id": "requestId"},
+            status=200,
+        )
+
+        responses.add(
+            responses.GET,
+            "http://token_auth_verification_url",
+            json={"is_valid": True, "other": {"nested": {"field": "something_here"}}},
+            status=200,
+        )
+
+        custom_auth = CustomTokenBackend()
+        request = MagicMock()
+        request.META.get.return_value = "Bearer AWESOME_TOKEN"
+
+        with self.settings(
+            SETTINGS_TOKEN_AUTH_URL="http://token_auth_url",
+            SETTINGS_TOKEN_AUTH_USER_FIELD="userId",
+            SETTINGS_TOKEN_AUTH_VERIFICATION_URL="http://token_auth_verification_url",
+            SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD="is_valid;other,nested,field",
+        ):
+            user, token = custom_auth.authenticate(request)
+
+            self.assertIsInstance(token, CustomToken)
+            self.assertEqual(token.token, b"AWESOME_TOKEN")
+
+            self.assertEqual(user.username, "AwesomeUser")
+
+        with self.settings(
+            SETTINGS_TOKEN_AUTH_URL="http://token_auth_url",
+            SETTINGS_TOKEN_AUTH_USER_FIELD="userId",
+            SETTINGS_TOKEN_AUTH_VERIFICATION_URL="http://token_auth_verification_url",
+            SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD="is_valid;other,WRONG_NESTED_FIELD",
+        ):
+            user, token = custom_auth.authenticate(request)
+
+            self.assertIsNone(user)
+            self.assertEqual(token.token, b"AWESOME_TOKEN")
+
+        responses.add(
+            responses.GET,
+            "http://token_auth_verification_url",
+            json={"is_valid": True, "other": "no nested fields"},
+            status=200,
+        )
+
+        with self.settings(
+            SETTINGS_TOKEN_AUTH_URL="http://token_auth_url",
+            SETTINGS_TOKEN_AUTH_USER_FIELD="userId",
+            SETTINGS_TOKEN_AUTH_VERIFICATION_URL="http://token_auth_verification_url",
+            SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD="is_valid;other,nested,field",
+        ):
+            # this should raise an error as `SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD`
+            # is not configured properly
+            with self.assertRaises(AttributeError):
+                custom_auth.authenticate(request)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Allow nested fields verification from auth API

### Details and comments

Now if verification API has structure something like that
```json
{
  "is_valid": true,
  "some": {
    "nested": {
      "field": true
    },
    "other": "bla"
  }
}
```

We can verify agains it with following settings:
```python
"SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD", "is_valid;some,nested,field"
```
---

Back compatible PR

Closes #1058 