### PR TITLE
Re-add Program as importable

### DIFF
--- a/client/quantum_serverless/core/__init__.py
+++ b/client/quantum_serverless/core/__init__.py
@@ -75,6 +75,7 @@ from .job import (
 )
 from .pattern import (
     QiskitPattern,
+    Program,
     ProgramStorage,
     ProgramRepository,
     download_and_unpack_artifact,


### PR DESCRIPTION
#1029 accidentally removed `Program` from being importable at the `core` level, when it is still in its deprecation period.

This PR re-adds that module as importable from the `core` package until its deprecation period is over. If we remove it, we've broken users' interface, which defeats the purpose of deprecating.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

I believe this is manifesting in strange Sphinx errors in `tox` builds (like the one happening in this PR).