### PR TITLE
pin cloudpickle to 2.2.1

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -3,7 +3,8 @@ requests>=2.31.0
 importlib-metadata>=5.2.0
 qiskit>=0.44.3
 qiskit-ibm-runtime>=0.13.0
-cloudpickle>=2.2.1
+# TODO: make sure ray node and notebook node have the same version of cloudpickle
+cloudpickle==2.2.1
 tqdm>=4.65.0
 # opentelemetry
 opentelemetry-api>=1.18.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
fix: #1090 


### Details and comments
Ray node build picks up cloudpickle 2.2.1 and notebook build picks up cloudpickle 3.0.0.  This PR makes both build pick up cloudpickle 2.2.1.
