### PR TITLE
Setup log level depending of the environment

### DIFF
--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -31,6 +31,9 @@ SECRET_KEY = os.environ.get(
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = int(os.environ.get("DEBUG", 1))
 
+# SECURITY WARNING: don't run with debug turned on in production!
+LOG_LEVEL = "DEBUG" if int(os.environ.get("DEBUG", 1)) else "WARNING"
+
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "*").split(",")
 
 # allow connections from any kubernetes pod within the cluster
@@ -111,17 +114,17 @@ LOGGING = {
     },
     "root": {
         "handlers": ["console"],
-        "level": "DEBUG",
+        "level": LOG_LEVEL,
     },
     "loggers": {
         "commands": {
             "handlers": ["console"],
-            "level": "DEBUG",
+            "level": LOG_LEVEL,
             "propagate": False,
         },
         "gateway": {
             "handlers": ["console"],
-            "level": "DEBUG",
+            "level": LOG_LEVEL,
             "propagate": False,
         },
     },


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix #727 . This PR setup different levels of logging depending of the `DEBUG` mode.

### Details and comments

- For `DEBUG=1` the gateway will print all the logs available
- For `DEBUG=0` the gateway will print the logs from **"WARNING"** and above (ref: [here](https://docs.djangoproject.com/en/4.2/topics/logging/#loggers))

In this case instead to add a new environment variable to manage the logs independently I opted for a way where the log level depends on the `DEBUG` mode to avoid to add more environment variables.
