### PR TITLE
Gateway: fix note image selection

### DIFF
--- a/gateway/api/ray.py
+++ b/gateway/api/ray.py
@@ -194,9 +194,9 @@ def create_ray_cluster(
             node_image = settings.RAY_NODE_IMAGES_MAP[job_config.python_version]
         else:
             message = (
-                "Specified python version {job_config.python_version} "
+                f"Specified python version {job_config.python_version} "
                 "not in a list of supported python versions "
-                "{list(settings.RAY_NODE_IMAGES_MAP.keys())}. "
+                f"{list(settings.RAY_NODE_IMAGES_MAP.keys())}. "
                 "Default image will be used instead."
             )
             logger.warning(message)

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -307,6 +307,7 @@ RAY_NODE_IMAGE = os.environ.get(
     "RAY_NODE_IMAGE", "icr.io/quantum-public/quantum-serverless-ray-node:0.7.1-py39"
 )
 RAY_NODE_IMAGES_MAP = {
+    "default": RAY_NODE_IMAGE,
     "py38": os.environ.get("RAY_NODE_IMAGE_PY38", RAY_NODE_IMAGE),
     "py39": os.environ.get("RAY_NODE_IMAGE_PY39", RAY_NODE_IMAGE),
     "py310": os.environ.get("RAY_NODE_IMAGE_PY310", RAY_NODE_IMAGE),


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Gateway: fix note image selection

### Details and comments

Currently if python version is not specified scheduler will try use `default` image in image map, which is not specified. This will lead to fall back to default behavior and log warning. 