### PR TITLE
Helm keycloak rollback

### DIFF
--- a/charts/quantum-serverless/Chart.lock
+++ b/charts/quantum-serverless/Chart.lock
@@ -13,9 +13,9 @@ dependencies:
   version: 0.6.1
 - name: keycloak
   repository: https://charts.bitnami.com/bitnami
-  version: 14.5.0
+  version: 13.4.1
 - name: repository
   repository: ""
   version: 0.8.0
-digest: sha256:0ffbab84718300ee27bad46ba3a2456f41260b51e1c119f64e753dd13e85af02
-generated: "2023-11-22T17:05:04.053955831Z"
+digest: sha256:16d9864c27fc63b007749e640965fb8ae11a6c5380a30bfa5f351a79ae360460
+generated: "2023-11-20T14:22:27.83668771Z"

--- a/charts/quantum-serverless/Chart.lock
+++ b/charts/quantum-serverless/Chart.lock
@@ -13,9 +13,9 @@ dependencies:
   version: 0.6.1
 - name: keycloak
   repository: https://charts.bitnami.com/bitnami
-  version: 15.1.8
+  version: 14.5.0
 - name: repository
   repository: ""
   version: 0.8.0
-digest: sha256:be980e202442f195b338dc7331cf1ef3db5dc2026f2d50754d254120319b3e52
-generated: "2023-11-22T18:29:42.332497725Z"
+digest: sha256:0ffbab84718300ee27bad46ba3a2456f41260b51e1c119f64e753dd13e85af02
+generated: "2023-11-22T17:05:04.053955831Z"

--- a/charts/quantum-serverless/Chart.yaml
+++ b/charts/quantum-serverless/Chart.yaml
@@ -24,7 +24,7 @@ dependencies:
     repository: https://ray-project.github.io/kuberay-helm
   - name: keycloak
     condition: keycloakEnable
-    version: 15.1.8
+    version: 14.5.0
     repository: https://charts.bitnami.com/bitnami
   - name: repository
     condition: repositoryEnable

--- a/charts/quantum-serverless/Chart.yaml
+++ b/charts/quantum-serverless/Chart.yaml
@@ -24,7 +24,7 @@ dependencies:
     repository: https://ray-project.github.io/kuberay-helm
   - name: keycloak
     condition: keycloakEnable
-    version: 14.5.0
+    version: 13.4.1
     repository: https://charts.bitnami.com/bitnami
   - name: repository
     condition: repositoryEnable

--- a/renovate.json
+++ b/renovate.json
@@ -19,13 +19,6 @@
         "^qiskit"
       ],
       "groupName": "qiskit packages"
-    },
-    {
-      "matchPackageNames": [
-        "nginx-ingress-controller",
-        "keycloak"
-      ],
-      "groupName": "bitnami packages"
     }
   ]
 }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Keycloak helm updates for #119 and #1120 were introducing Keycloak 21.1.X, version with what we are not compatible yet. This PR rollbacks to v13 version of keycloak helm that it was using 20.0.5 with what we are compatible.

I removed bitnami packages from renovate too thinking that even if they need to be updated at the same time we are going to do it manually and testing each package separately.

Probably PR related with:
- #1124 
- #1123 
- #1122 
- #1007 
- #954

Ref: #1088 