### PR TITLE
 Test building images against multiple python versions

### DIFF
--- a/.github/workflows/build-containers-test.yaml
+++ b/.github/workflows/build-containers-test.yaml
@@ -1,0 +1,67 @@
+name: Build the containers
+
+on:
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-containers:
+    name: build-containers
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # keep running if one leg fails
+      matrix:
+        dockerfile:
+          - Dockerfile-ray-node
+          - Dockerfile-notebook
+          - repository/Dockerfile
+          - gateway/Dockerfile
+        python:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+        exclude:
+          # gateway is only built using python 3.9
+          - dockerfile: gateway/Dockerfile
+            python: "3.8"
+          - dockerfile: gateway/Dockerfile
+            python: "3.10"
+          # repository is only built using python 3.9
+          - dockerfile: repository/Dockerfile
+            python: "3.8"
+          - dockerfile: repository/Dockerfile
+            python: "3.10"
+
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Config python value
+        run: |
+          python_version=${{ matrix.python }}
+          dockerfile=${{ matrix.dockerfile }}
+          # ray-node image uses different string for python version
+          if [[ "$dockerfile" == *"ray-node" ]]
+          then
+            new_version=${python_version//.}
+            echo "python_version=py$new_version" >> "$GITHUB_ENV"
+          else
+            echo "python_version=$python_version" >> "$GITHUB_ENV"
+          fi
+      - name: Build ${{ matrix.dockerfile }} using python ${{ matrix.python }}
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./${{ matrix.dockerfile }}
+          load: true
+          tags: image:test
+          build-args:
+            IMAGE_PY_VERSION=${{ env.python_version }}
+      - name: Inspect
+        run: |
+          docker image inspect image:test

--- a/.github/workflows/client-verify.yaml
+++ b/.github/workflows/client-verify.yaml
@@ -9,9 +9,13 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false # keep running if one leg fails
       matrix:
-        python-version: ['3.9']
-    
+        python-version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+
     defaults:
       run:
         working-directory: ./client
@@ -38,7 +42,7 @@ jobs:
 
       - name: Run styles check
         run: tox -elint
-      
+
       - name: Test using tox environment
         run: |
           tox ${{ env.TOX_ENV }}

--- a/.github/workflows/gateway-verify.yaml
+++ b/.github/workflows/gateway-verify.yaml
@@ -9,9 +9,13 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false # keep running if one leg fails
       matrix:
-        python-version: ['3.9']
-    
+        python-version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+
     defaults:
       run:
         working-directory: ./gateway
@@ -38,7 +42,7 @@ jobs:
 
       - name: Run styles check
         run: tox -elint
-      
+
       - name: Test using tox environment
         run: |
           tox ${{ env.TOX_ENV }}

--- a/.github/workflows/repository-verify.yaml
+++ b/.github/workflows/repository-verify.yaml
@@ -9,8 +9,12 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false # keep running if one leg fails
       matrix:
-        python-version: ['3.9']
+        python-version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
 
     defaults:
       run:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #1050 

Test building images for Python 3.8, 3.9, and 3.10 
Lint against the same Python versions

### Details and comments

We've run into issues (e.g. https://github.com/Qiskit-Extensions/quantum-serverless/issues/1037) where some Python versions that we build images for end up failing when we cut a new release. 

This PR adds a test to build images against all supported python versions on each PR. 

All builds are run in parallel, and the complete run of all builds takes **under 5 minutes** in local testing.

I've also bumped updated the client / repository / gateway lint jobs to use all 3 python versions... if we're building images for a python version, we may as well check the code too (though I wouldn't be opposed to removing this if folks think it's overkill)
