### PR TITLE
Pin testcontainers version

### DIFF
--- a/client/requirements-dev.txt
+++ b/client/requirements-dev.txt
@@ -14,5 +14,6 @@ reno>=3.5.0
 # the ~= specifier for it.
 black[jupyter]~=22.12
 requests-mock>=1.11.0
-testcontainers>=3.7.1
+# new versions of testcontainers don't support docker compose
+testcontainers==3.7.1
 tox>=4.0.0


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

The testcontainers project dropped support for docker compose, which we use in several of our tests. In order to keep that functionality, this PR pins to a version that still supports compose.

