### PR TITLE
Run image builds as separate jobs

### DIFF
--- a/.github/actions/icr-build-and-push-images/action.yaml
+++ b/.github/actions/icr-build-and-push-images/action.yaml
@@ -1,53 +1,47 @@
 name: 'Build and push images'
 description: 'Builds and pushes images to remote repository'
 inputs:
-  tag:
-    description: 'Tag of image that will be build'
+  name:
+    description: 'Image name'
     required: true
+  tag:
+    description: 'Release version'
+    required: true
+  dockerfile:
+    description: 'Location of dockerfile'
+    required: true
+  platforms:
+    description: '(optional) platform to build image for'
+    required: false
+    default: "linux/amd64"
+  repository:
+    description: '(optional) repository'
+    required: false
+    default: 'icr.io/quantum-public'
+  pythonversion:
+    description: '(optional) python version'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
-    - name: Build and push node image [3.8]
-      uses: docker/build-push-action@v3
+    - name: Build and push image with Python Version
+      if: ${{inputs.pythonversion}} != ''
+      uses: docker/build-push-action@v5
       with:
+        platforms: ${{inputs.platforms}}
         context: .
-        file: Dockerfile-ray-node
+        file: ${{inputs.dockerfile}}
         push: true
-        tags: icr.io/quantum-public/quantum-serverless-ray-node:${{inputs.tag}}-py38,icr.io/quantum-public/quantum-serverless-ray-node:latest-py38
+        tags: ${{inputs.repository}}/${{inputs.name}}:${{inputs.tag}}-${{inputs.pythonversion}},${{inputs.repository}}/${{inputs.name}}:latest-${{inputs.pythonversion}}
         build-args:
-          IMAGE_PY_VERSION=py38
-    - name: Build and push node image [3.9]
-      uses: docker/build-push-action@v3
+          IMAGE_PY_VERSION=${{inputs.pythonversion}}
+    - name: Build and push image
+      if: ${{inputs.pythonversion}} == ''
+      uses: docker/build-push-action@v5
       with:
-        platforms: linux/amd64,linux/arm64
+        platforms: ${{inputs.platforms}}
         context: .
-        file: Dockerfile-ray-node
+        file: ${{inputs.dockerfile}}
         push: true
-        tags: icr.io/quantum-public/quantum-serverless-ray-node:${{inputs.tag}}-py39,icr.io/quantum-public/quantum-serverless-ray-node:latest-py39
-        build-args:
-          IMAGE_PY_VERSION=py39
-    - name: Build and push node image [3.10]
-      uses: docker/build-push-action@v3
-      with:
-        context: .
-        file: Dockerfile-ray-node
-        push: true
-        tags: icr.io/quantum-public/quantum-serverless-ray-node:${{inputs.tag}}-py310,icr.io/quantum-public/quantum-serverless-ray-node:latest-py310
-        build-args:
-          IMAGE_PY_VERSION=py310
-    - name: Build and push repository server
-      uses: docker/build-push-action@v3
-      with:
-        platforms: linux/amd64,linux/arm64
-        context: .
-        file: ./repository/Dockerfile
-        push: true
-        tags: icr.io/quantum-public/quantum-repository-server:${{inputs.tag}},icr.io/quantum-public/quantum-repository-server:latest
-    - name: Build and push gateway
-      uses: docker/build-push-action@v3
-      with:
-        platforms: linux/amd64,linux/arm64
-        context: .
-        file: ./gateway/Dockerfile
-        push: true
-        tags: icr.io/quantum-public/quantum-serverless-gateway:${{inputs.tag}},icr.io/quantum-public/quantum-serverless-gateway:latest
+        tags: ${{inputs.repository}}/${{inputs.name}}:${{inputs.tag}},${{inputs.repository}}/${{inputs.name}}:latest

--- a/.github/workflows/icr-image-build-and-push.yaml
+++ b/.github/workflows/icr-image-build-and-push.yaml
@@ -12,6 +12,29 @@ on:
 jobs:
   icr_build_and_push:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - imagename: quantum-serverless-ray-node
+            pythonversion: py38
+            dockerfile: Dockerfile-ray-node
+            platforms: linux/amd64
+         - imagename: quantum-serverless-ray-node
+            pythonversion: py39
+            dockerfile: Dockerfile-ray-node
+            platforms: linux/amd64,linux/arm64
+         - imagename: quantum-serverless-ray-node
+            pythonversion: py310
+            dockerfile: Dockerfile-ray-node
+            platforms: linux/amd64
+         - imagename: quantum-repository-server
+            pythonversion: ''
+            dockerfile: ./repository/Dockerfile
+            platforms: linux/amd64,linux/arm64
+         - imagename: quantum-serverless-gateway
+            pythonversion: ''
+            dockerfile: ./gateway/Dockerfile
+            platforms: linux/amd64,linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -32,6 +55,10 @@ jobs:
         uses: ./.github/actions/icr-build-and-push-images
         with:
           tag: ${{ github.event.inputs.tag }}
+          name: ${{ matrix.imagename }}
+          dockerfile: ${{ matrix.dockerfile }}
+          platforms: ${{ matrix.platforms }}
+          pythonversion: ${{ matrix.pythonversion }}
       - name: Set version from tag
         if : github.event_name == 'release' && github.event.action == 'published'
         id: set-version-from-tag
@@ -41,3 +68,7 @@ jobs:
         uses: ./.github/actions/icr-build-and-push-images
         with:
           tag: ${{ steps.set-version-from-tag.outputs.VERSION }}
+          name: ${{ matrix.imagename }}
+          dockerfile: ${{ matrix.dockerfile }}
+          platforms: ${{ matrix.platforms }}
+          pythonversion: ${{ matrix.pythonversion }}

--- a/Dockerfile-notebook
+++ b/Dockerfile-notebook
@@ -2,10 +2,10 @@ ARG IMAGE_PY_VERSION=3.9
 FROM jupyter/base-notebook:python-$IMAGE_PY_VERSION
 
 USER 0
-RUN apt-get -y update &&\ 
-    apt-get install --no-install-recommends -y \ 
+RUN apt-get -y update &&\
+    apt-get install --no-install-recommends -y \
     gcc=4:11.2.0-1ubuntu1 \
-    build-essential=12.9ubuntu3 \ 
+    build-essential=12.9ubuntu3 \
     libopenblas-dev=0.3.20+ds-1 &&\
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

We found that running all image builds as a single job could create a bottleneck, so we decided to split them into separate jobs. This should also make reviewing logs easier, as there should be less output for the web UI to have to render.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

