### PR TITLE
Remove notebook/compose mentions from docs

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -1,18 +1,5 @@
 # compose config for running images based on local files
 services:
-  jupyter:
-    container_name: qs-jupyter
-    build:
-      context: ./
-      dockerfile: Dockerfile-notebook
-    profiles: ["jupyter", "full"]
-    ports:
-      - 8888:8888
-    environment:
-      - JUPYTER_TOKEN=123
-      - GATEWAY_HOST=http://gateway:8000
-    networks:
-      - safe-tier
   ray-head:
     container_name: ray-head
     build:

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -1,5 +1,18 @@
 # compose config for running images based on local files
 services:
+  jupyter:
+    container_name: qs-jupyter
+    build:
+      context: ./
+      dockerfile: Dockerfile-notebook
+    profiles: ["jupyter", "full"]
+    ports:
+      - 8888:8888
+    environment:
+      - JUPYTER_TOKEN=123
+      - GATEWAY_HOST=http://gateway:8000
+    networks:
+      - safe-tier
   ray-head:
     container_name: ray-head
     build:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,16 +1,5 @@
 # compose config on latest release builds
 services:
-  jupyter:
-    container_name: qs-jupyter
-    image: icr.io/quantum-public/quantum-serverless-notebook:${VERSION:-0.8.2}-py39
-    profiles: ["jupyter", "full"]
-    ports:
-      - 8888:8888
-    environment:
-      - JUPYTER_TOKEN=123
-      - GATEWAY_HOST=http://gateway:8000
-    networks:
-      - safe-tier
   ray-head:
     container_name: ray-head
     image: icr.io/quantum-public/quantum-serverless-ray-node:${VERSION:-0.8.2}-py39

--- a/docs/deployment/cloud.rst
+++ b/docs/deployment/cloud.rst
@@ -55,20 +55,17 @@ If you have ``docker compose`` available you can run the next command in your te
 .. code-block::
    :caption: run the command from the root of the project
 
-        $ docker compose --profile jupyter up
+        $ docker compose up
 
 Once the execution of the command has finished, if everything went well you should be able to open the browser
-and have access to:
-
-* Jupyter notebook: http://localhost:8888
-* Ray dashboard: http://localhost:8265
+and have access to the Ray dashboard at: http://localhost:8265
 
 In case you want to use the ``main`` branch you can use the configuration for development running the next command:
 
 .. code-block::
    :caption: run the command from the root of the project
 
-        $ docker compose -f docker-compose-dev.yaml --profile jupyter up
+        $ docker compose -f docker-compose-dev.yaml up
 
 .. _helm-deployment:
 

--- a/docs/deployment/local.rst
+++ b/docs/deployment/local.rst
@@ -46,15 +46,13 @@ Once you have Docker and docker compose installed, you can run the following com
 
         $ docker compose [--profile <PROFILE>] up
 
-The available profiles are `full`, `jupyter`, and `repo`.
+The available profiles are `full` and `repo`.
 The repo profile installs core services and the program repository;
-the jupyter profile installs core services and Jupyter Notebook;
 and the full profile installs all core services, including logging and
-monitorying systems and jupyter.
+monitorying systems.
 
 Step 4: Run a program in the test environment
 
 Once the containers are running, you can simulate a remote cluster with the resources on your
-local machine. To create and run programs in this simulated cluster, visit the Jupyter Lab
-environment at `localhost:8888` via a web browser. Refer to the :ref:`getting_started` guides
+local machine. To create and run programs in this simulated cluster, we recommend using [Jupyter Lab](https://jupyter.org/install). Refer to the :ref:`getting_started` guides
 for details about running your program remotely.


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

Fixes #1174

We stopped building the notebook as of v0.8.2 (see discussion in

Eventually we plan on migrating these docs to IQP, which will remove the docker compose option, so the local install section might be a little rough after this edit, but it will be cleaned up once we tackle

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

