### PR TITLE
Add vim to images

### DIFF
--- a/Dockerfile-ray-node
+++ b/Dockerfile-ray-node
@@ -4,6 +4,7 @@ FROM rayproject/ray:2.9.0-$IMAGE_PY_VERSION AS ray-node-amd64
 
 WORKDIR /
 USER 0
+RUN apt-get update && apt-get install -y vim
 RUN mkdir /data && chown "$RAY_UID":"$RAY_UID" /data
 USER $RAY_UID
 COPY --chown=$RAY_UID:$RAY_UID ./client ./qs
@@ -15,7 +16,7 @@ RUN pip install . --no-cache-dir &&\
     pip install --no-cache-dir pyarrow==14.0.1 &&\
     pip install --no-cache-dir certifi==2023.7.22
 
-WORKDIR / 
+WORKDIR /
 RUN rm -r ./qs
 
 FROM rayproject/ray:2.9.0-$IMAGE_PY_VERSION-aarch64 AS ray-node-arm64
@@ -24,9 +25,9 @@ WORKDIR /
 USER 0
 RUN mkdir /data && chown "$RAY_UID":"$RAY_UID" /data
 USER $RAY_UID
-RUN apt-get -y update &&\ 
-    apt-get install --no-install-recommends -y \ 
-    gcc=4:9.3.0-1ubuntu2 \ 
+RUN apt-get -y update &&\
+    apt-get install --no-install-recommends -y \
+    gcc=4:9.3.0-1ubuntu2 vim \
     build-essential=12.8ubuntu1
 COPY --chown=$RAY_UID:$RAY_UID ./client ./qs
 

--- a/Dockerfile-ray-node
+++ b/Dockerfile-ray-node
@@ -4,7 +4,6 @@ FROM rayproject/ray:2.9.0-$IMAGE_PY_VERSION AS ray-node-amd64
 
 WORKDIR /
 USER 0
-RUN apt-get update && apt-get install -y vim
 RUN mkdir /data && chown "$RAY_UID":"$RAY_UID" /data
 USER $RAY_UID
 COPY --chown=$RAY_UID:$RAY_UID ./client ./qs
@@ -27,7 +26,7 @@ RUN mkdir /data && chown "$RAY_UID":"$RAY_UID" /data
 USER $RAY_UID
 RUN apt-get -y update &&\
     apt-get install --no-install-recommends -y \
-    gcc=4:9.3.0-1ubuntu2 vim \
+    gcc=4:9.3.0-1ubuntu2 \
     build-essential=12.8ubuntu1
 COPY --chown=$RAY_UID:$RAY_UID ./client ./qs
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -8,7 +8,7 @@ ENV PYTHONUNBUFFERED 1
 
 # install psycopg2 dependencies
 RUN apt-get -y update &&\
-    apt-get install --no-install-recommends -y gcc=4:8.3.0-1 python3-dev=3.7.3-1 &&\
+    apt-get install --no-install-recommends -y gcc=4:8.3.0-1 python3-dev=3.7.3-1 vim &&\
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/*
 

--- a/repository/Dockerfile
+++ b/repository/Dockerfile
@@ -7,6 +7,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
 USER 0
+RUN apt-get update && apt-get install -y vim
 COPY repository .
 RUN chown -R 1001:0 /usr/src/app &&\
     pip install -r requirements.txt --no-cache-dir


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

We've found that having vim available on images is useful when needing to debug. So this PR adds it to the ray-node, gateway, and repository images.

