### PR TITLE
Drop markdown from gateway/repository requirements

### DIFF
--- a/client/requirements-dev.txt
+++ b/client/requirements-dev.txt
@@ -17,3 +17,4 @@ requests-mock>=1.11.0
 # new versions of testcontainers don't support docker compose
 testcontainers==3.7.1
 tox>=4.0.0
+nbmake>=1.4.6

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -1,6 +1,5 @@
 django-filter>=23.3
 djangorestframework>=3.14.0
-Markdown>=3.5.1
 django-allauth>=0.58.2
 django-allow-cidr>=0.7.1
 dj-rest-auth>=5.0.2

--- a/repository/requirements.txt
+++ b/repository/requirements.txt
@@ -5,7 +5,6 @@ django-filter>=23.3
 django_prometheus>=2.3.1
 djangorestframework>=3.14.0
 importlib-metadata>=6.0.0
-Markdown>=3.5.1
 pytz>=2022.7.1
 sqlparse>=0.4.4
 zipp>=3.15.0


### PR DESCRIPTION
xref #1178 

Also adds `nbmake` to client dev requirements, so that notebook tests can be run directly from the command line.