### PR TITLE
CatalogEntry API

### DIFF
--- a/gateway/api/permissions.py
+++ b/gateway/api/permissions.py
@@ -13,3 +13,14 @@ class IsOwner(permissions.BasePermission):
         if isinstance(obj, RuntimeJob):
             return obj.job.author == request.user
         return obj.author == request.user
+
+
+class CatalogUpdate(permissions.BasePermission):
+    """
+    Custom permission to only allow owners of an object to update it.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        if request.method == "GET":
+            return True
+        return obj.program.author == request.user

--- a/gateway/api/serializers.py
+++ b/gateway/api/serializers.py
@@ -91,8 +91,21 @@ class RuntimeJobSerializer(serializers.ModelSerializer):
 
 class CatalogEntrySerializer(serializers.ModelSerializer):
     """
-    Serializer for the catalog entry model.
+    Serializer for the catalog entry.
     """
 
     class Meta:
         model = CatalogEntry
+
+        fields = ["id", "title", "description", "tags", "program"]
+
+
+class ToCatalogSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the to catalog.
+    """
+
+    class Meta:
+        model = CatalogEntry
+
+        fields = ["id", "title", "description", "tags"]

--- a/gateway/api/serializers.py
+++ b/gateway/api/serializers.py
@@ -8,7 +8,7 @@ Version serializers inherit from the different serializers.
 
 from django.conf import settings
 from rest_framework import serializers
-from .models import Program, Job, JobConfig, RuntimeJob
+from .models import Program, Job, JobConfig, RuntimeJob, CatalogEntry
 
 
 class JobConfigSerializer(serializers.ModelSerializer):
@@ -87,3 +87,12 @@ class RuntimeJobSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = RuntimeJob
+
+
+class CatalogEntrySerializer(serializers.ModelSerializer):
+    """
+    Serializer for the catalog entry model.
+    """
+
+    class Meta:
+        model = CatalogEntry

--- a/gateway/api/v1/serializers.py
+++ b/gateway/api/v1/serializers.py
@@ -73,3 +73,10 @@ class CatalogEntrySerializer(serializers.CatalogEntrySerializer):
 
     class Meta(serializers.CatalogEntrySerializer.Meta):
         fields = ["id", "title", "description", "tags", "created", "updated", "program"]
+
+
+class ToCatalogSerializer(serializers.ToCatalogSerializer):
+    """
+    To catalog serializer first version.
+    This serializer limitates the fields from CatalogEntry.
+    """

--- a/gateway/api/v1/serializers.py
+++ b/gateway/api/v1/serializers.py
@@ -62,3 +62,14 @@ class RuntimeJobSerializer(serializers.RuntimeJobSerializer):
 
     class Meta(serializers.RuntimeJobSerializer.Meta):
         fields = ["job", "runtime_job"]
+
+
+class CatalogEntrySerializer(serializers.CatalogEntrySerializer):
+    """
+    Catalog entry serializer first version. Serializer for the catalog entry model.
+    """
+
+    program = ProgramSerializer(many=False)
+
+    class Meta(serializers.CatalogEntrySerializer.Meta):
+        fields = ["id", "title", "description", "tags", "created", "updated", "program"]

--- a/gateway/api/v1/urls.py
+++ b/gateway/api/v1/urls.py
@@ -24,5 +24,10 @@ router.register(
     v1_views.RuntimeJobViewSet,
     basename=v1_views.RuntimeJobViewSet.BASE_NAME,
 )
+router.register(
+    r"catalog_entries",
+    v1_views.CatalogEntryViewSet,
+    basename=v1_views.CatalogEntryViewSet.BASE_NAME,
+)
 
 urlpatterns = router.urls

--- a/gateway/api/v1/views.py
+++ b/gateway/api/v1/views.py
@@ -6,8 +6,8 @@ from rest_framework import permissions
 
 
 from api import views
-from api.models import Program, Job, RuntimeJob
-from api.permissions import IsOwner
+from api.models import Program, Job, RuntimeJob, CatalogEntry
+from api.permissions import IsOwner, CatalogUpdate
 from . import serializers as v1_serializers
 from . import services as v1_services
 
@@ -83,3 +83,20 @@ class RuntimeJobViewSet(views.RuntimeJobViewSet):  # pylint: disable=too-many-an
 
     def get_queryset(self):
         return RuntimeJob.objects.all().filter(job__author=self.request.user)
+
+
+class CatalogEntryViewSet(
+    views.CatalogEntryViewSet
+):  # pylint: disable=too-many-ancestors
+    """
+    CatalogEntry view set first version. Use CatalogEntrySerializer V1.
+    """
+
+    serializer_class = v1_serializers.CatalogEntrySerializer
+    permission_classes = [permissions.IsAuthenticated, CatalogUpdate]
+
+    def get_serializer_class(self):
+        return v1_serializers.CatalogEntrySerializer
+
+    def get_queryset(self):
+        return CatalogEntry.objects.all()

--- a/gateway/api/views.py
+++ b/gateway/api/views.py
@@ -29,7 +29,7 @@ from rest_framework.response import Response
 from utils import sanitize_file_path
 
 from .exceptions import InternalServerErrorException, ResourceNotFoundException
-from .models import Program, Job, RuntimeJob
+from .models import Program, Job, RuntimeJob, CatalogEntry
 from .ray import get_job_handler
 from .serializers import JobSerializer, ExistingProgramSerializer, JobConfigSerializer
 from .services import JobService, ProgramService, JobConfigService
@@ -521,3 +521,17 @@ class RuntimeJobViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ance
 
     def get_queryset(self):
         return RuntimeJob.objects.all().filter(job__author=self.request.user)
+
+
+class CatalogEntryViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
+    """
+    CatalogEntry ViewSet configuration using ModelViewSet.
+    """
+
+    BASE_NAME = "catalog_entries"
+
+    def get_serializer_class(self):
+        return self.serializer_class
+
+    def get_queryset(self):
+        return CatalogEntry.objects.all()

--- a/gateway/api/views.py
+++ b/gateway/api/views.py
@@ -31,7 +31,13 @@ from utils import sanitize_file_path
 from .exceptions import InternalServerErrorException, ResourceNotFoundException
 from .models import Program, Job, RuntimeJob, CatalogEntry
 from .ray import get_job_handler
-from .serializers import JobSerializer, ExistingProgramSerializer, JobConfigSerializer
+from .serializers import (
+    JobSerializer,
+    ExistingProgramSerializer,
+    JobConfigSerializer,
+    CatalogEntrySerializer,
+    ToCatalogSerializer,
+)
 from .services import JobService, ProgramService, JobConfigService
 
 logger = logging.getLogger("gateway")
@@ -104,6 +110,22 @@ class ProgramViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancesto
         """
 
         return JobConfigSerializer
+
+    @staticmethod
+    def get_serializer_catalog_entry_class():
+        """
+        This method returns add catalog entry serializer to be used in Program ViewSet.
+        """
+
+        return CatalogEntrySerializer
+
+    @staticmethod
+    def get_serializer_to_catalog_class():
+        """
+        This method returns to catalog serializer to be used in Program ViewSet.
+        """
+
+        return ToCatalogSerializer
 
     def get_serializer_class(self):
         return self.serializer_class
@@ -254,6 +276,35 @@ class ProgramViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancesto
 
             job_serializer = self.get_serializer_job_class()(job)
         return Response(job_serializer.data)
+
+    @action(methods=["POST"], detail=True)
+    def to_catalog(self, request, pk=None):  # pylint: disable=unused-argument
+        """To catalog."""
+        tracer = trace.get_tracer("gateway.tracer")
+        ctx = TraceContextTextMapPropagator().extract(carrier=request.headers)
+        with tracer.start_as_current_span("gateway.program.to_catalog", context=ctx):
+            serializer = self.get_serializer_to_catalog_class()(data=request.data)
+            if not serializer.is_valid():
+                return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            if not self.get_object().public:
+                return Response(
+                    "program must be public", status=status.HTTP_400_BAD_REQUEST
+                )
+
+            try:
+                catalogentry = CatalogEntry(
+                    title=serializer.data.get("title"),
+                    description=serializer.data.get("description"),
+                    tags=serializer.data.get("tags"),
+                    program=self.get_object(),
+                )
+                catalogentry.save()
+            except InternalServerErrorException as exception:
+                return Response(exception, status=status.HTTP_400_BAD_REQUEST)
+            catalog_entry_serializer = self.get_serializer_catalog_entry_class()(
+                catalogentry
+            )
+        return Response(catalog_entry_serializer.data)
 
 
 class JobViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
@@ -535,3 +586,23 @@ class CatalogEntryViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-an
 
     def get_queryset(self):
         return CatalogEntry.objects.all()
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        title = request.query_params.get("title")
+        description = request.query_params.get("description")
+        tags = request.query_params.get("tags")
+        if title:
+            queryset = queryset.filter(title__contains=title)
+        if description:
+            queryset = queryset.filter(description__contains=description)
+        if tags:
+            queryset = queryset.filter(tags__contains=tags)
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)

--- a/gateway/tests/api/test_v1_program.py
+++ b/gateway/tests/api/test_v1_program.py
@@ -292,3 +292,99 @@ class TestProgramApi(APITestCase):
         self.assertEqual(programs_response.status_code, status.HTTP_200_OK)
         self.assertEqual(programs_response.json().get("count"), 1)
         self.assertNotEqual(programs_response.json()["results"][0]["id"], id)
+
+    def test_to_catalog(self):
+        """Tests add catalog entry."""
+
+        auth = reverse("rest_login")
+        response = self.client.post(
+            auth, {"username": "test_user", "password": "123"}, format="json"
+        )
+        token = response.data.get("access")
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer " + token)
+
+        # to catalog entry
+        programs_response = self.client.post(
+            "/api/v1/programs/1a7947f9-6ae8-4e3d-ac1e-e7d608deec82/to_catalog/",
+            data={
+                "title": "AddedCatalog",
+                "description": "description of AddedCatalog",
+                "tags": "[tag1, tag2]",
+            },
+            format="json",
+        )
+        self.assertEqual(programs_response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        programs_response = self.client.patch(
+            "/api/v1/programs/1a7947f9-6ae8-4e3d-ac1e-e7d608deec82/",
+            data={
+                "public": True,
+            },
+            format="json",
+        )
+        self.assertEqual(programs_response.status_code, status.HTTP_200_OK)
+
+        # to catalog entry
+        programs_response = self.client.post(
+            "/api/v1/programs/1a7947f9-6ae8-4e3d-ac1e-e7d608deec82/to_catalog/",
+            data={
+                "title": "AddedCatalog",
+                "description": "description of AddedCatalog",
+                "tags": "[tag1, tag2]",
+            },
+            format="json",
+        )
+        self.assertEqual(programs_response.status_code, status.HTTP_200_OK)
+
+        # list catalog
+        programs_response = self.client.get(
+            "/api/v1/catalog_entries/",
+            format="json",
+        )
+        self.assertEqual(programs_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(programs_response.json().get("count"), 3)
+
+    def test_list_catalog_entry(self):
+        """Tests list catalog entry."""
+
+        auth = reverse("rest_login")
+        response = self.client.post(
+            auth, {"username": "test_user", "password": "123"}, format="json"
+        )
+        token = response.data.get("access")
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer " + token)
+
+        programs_response = self.client.get(
+            "/api/v1/catalog_entries/?tags=tag3",
+            format="json",
+        )
+        self.assertEqual(programs_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(programs_response.json().get("count"), 1)
+
+        programs_response = self.client.get(
+            "/api/v1/catalog_entries/?tags=tag2",
+            format="json",
+        )
+        self.assertEqual(programs_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(programs_response.json().get("count"), 1)
+
+        programs_response = self.client.get(
+            "/api/v1/catalog_entries/?title=Entry1",
+            format="json",
+        )
+        self.assertEqual(programs_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(programs_response.json().get("count"), 1)
+
+        programs_response = self.client.get(
+            "/api/v1/catalog_entries/?title=Entry",
+            format="json",
+        )
+        self.assertEqual(programs_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(programs_response.json().get("count"), 2)
+
+        programs_response = self.client.get(
+            "/api/v1/catalog_entries/?description=1",
+            format="json",
+        )
+        self.assertEqual(programs_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(programs_response.json().get("count"), 1)

--- a/gateway/tests/fixtures/fixtures.json
+++ b/gateway/tests/fixtures/fixtures.json
@@ -94,5 +94,28 @@
       "job": "1a7947f9-6ae8-4e3d-ac1e-e7d608deec84",
       "runtime_job": "runtime_job_5"
     }
+  },
+  {
+    "model": "api.catalogentry",
+    "fields": {
+      "title": "CatalogEntry1",
+      "description": "tast catalog entry 1",
+      "tags": "tag1, tag2",
+      "created": "2023-02-01T15:30:43.281796Z",
+      "updated": "2023-02-03T15:30:43.281796Z",
+      "program": "1a7947f9-6ae8-4e3d-ac1e-e7d608deec82"
+    }
+  },
+  {
+    "model": "api.catalogentry",
+    "fields": {
+      "title": "CatalogEntry2",
+      "description": "tast catalog entry 2",
+      "tags": "tag3",
+      "created": "2023-03-01T15:30:43.281796Z",
+      "updated": "2023-03-03T15:30:43.281796Z",
+      "program": "1a7947f9-6ae8-4e3d-ac1e-e7d608deec82"
+    }
   }
 ]
+


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Part of #1170 


### Details and comments
This PR adds [ModelView APIs](https://github.com/Qiskit-Extensions/quantum-serverless/issues/1170#issuecomment-1917931921) for CatalogEntry. 

The list method will be enhanced to handle the query string for `title`, `description` and `tags`.


