### PR TITLE
Fix link for Qiskit deprecation policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ For information on how to contribute to this project, please take a look at our 
 
 ### Deprecation Policy
 
-This project is meant to evolve rapidly and, as such, do not follow [Qiskit's deprecation policy](https://qiskit.org/documentation/contributing_to_qiskit.html#deprecation-policy).  We may occasionally make breaking changes in order to improve the user experience.  When possible, we will keep old interfaces and mark them as deprecated, as long as they can co-exist with the new ones.  Each substantial improvement, breaking change, or deprecation will be documented in release notes.
+This project is meant to evolve rapidly and, as such, do not follow [Qiskit's deprecation policy](https://github.com/Qiskit/qiskit/blob/main/DEPRECATION.md).  We may occasionally make breaking changes in order to improve the user experience.  When possible, we will keep old interfaces and mark them as deprecated, as long as they can co-exist with the new ones.  Each substantial improvement, breaking change, or deprecation will be documented in release notes.
 
 
 ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This was the only remaining link to `qiskit.org`.