### PR TITLE
Replace deprecated test providers

### DIFF
--- a/client/tests/library/test_transpiler.py
+++ b/client/tests/library/test_transpiler.py
@@ -15,7 +15,7 @@ from unittest import TestCase
 
 from qiskit import QuantumCircuit
 from qiskit.circuit.random import random_circuit
-from qiskit.providers.fake_provider import Fake20QV1, FakeBrooklynV2
+from qiskit.providers.fake_provider import Fake20QV1, GenericBackendV2
 
 from quantum_serverless import QuantumServerless
 from quantum_serverless.exception import QuantumServerlessException
@@ -32,7 +32,7 @@ class TestParallelTranspile(TestCase):
         circuit2 = random_circuit(5, 3)
 
         backend1 = Fake20QV1()
-        backend2 = FakeBrooklynV2()
+        backend2 = GenericBackendV2()
 
         with QuantumServerless().context():
             transpiled_circuits = parallel_transpile(
@@ -49,7 +49,7 @@ class TestParallelTranspile(TestCase):
         circuit1 = random_circuit(5, 3)
 
         backend1 = Fake20QV1()
-        backend2 = FakeBrooklynV2()
+        backend2 = GenericBackendV2()
 
         with QuantumServerless().context():
             # inconsistent number of circuits and backends

--- a/client/tests/library/test_transpiler.py
+++ b/client/tests/library/test_transpiler.py
@@ -32,7 +32,7 @@ class TestParallelTranspile(TestCase):
         circuit2 = random_circuit(5, 3)
 
         backend1 = Fake20QV1()
-        backend2 = GenericBackendV2()
+        backend2 = GenericBackendV2(num_qubits=5)
 
         with QuantumServerless().context():
             transpiled_circuits = parallel_transpile(
@@ -49,7 +49,7 @@ class TestParallelTranspile(TestCase):
         circuit1 = random_circuit(5, 3)
 
         backend1 = Fake20QV1()
-        backend2 = GenericBackendV2()
+        backend2 = GenericBackendV2(num_qubits=5)
 
         with QuantumServerless().context():
             # inconsistent number of circuits and backends

--- a/client/tests/library/test_transpiler.py
+++ b/client/tests/library/test_transpiler.py
@@ -15,7 +15,7 @@ from unittest import TestCase
 
 from qiskit import QuantumCircuit
 from qiskit.circuit.random import random_circuit
-from qiskit.providers.fake_provider import FakeAlmadenV2, FakeBrooklynV2
+from qiskit.providers.fake_provider import Fake20QV1, FakeBrooklynV2
 
 from quantum_serverless import QuantumServerless
 from quantum_serverless.exception import QuantumServerlessException
@@ -31,7 +31,7 @@ class TestParallelTranspile(TestCase):
         circuit1 = random_circuit(5, 3)
         circuit2 = random_circuit(5, 3)
 
-        backend1 = FakeAlmadenV2()
+        backend1 = Fake20QV1()
         backend2 = FakeBrooklynV2()
 
         with QuantumServerless().context():
@@ -48,7 +48,7 @@ class TestParallelTranspile(TestCase):
         """Test failing cases for parallel transpile."""
         circuit1 = random_circuit(5, 3)
 
-        backend1 = FakeAlmadenV2()
+        backend1 = Fake20QV1()
         backend2 = FakeBrooklynV2()
 
         with QuantumServerless().context():


### PR DESCRIPTION
Fixes #1225 
See client verify processes (3.8, 3.9, 3.10) are now passing.

### Summary
Followed replacement chart in [this qiskit PR](https://github.com/Qiskit/qiskit/pull/10952).
Note the replacement chart above only has instructions for replacing `FakeAlmaden` to [Fake20QV1](https://docs.quantum.ibm.com/api/qiskit/qiskit.providers.fake_provider.Fake20QV1).
`FakeBrooklyn` has been replaced by a generic fake provider [GenericBackendV2](https://docs.quantum.ibm.com/api/qiskit/qiskit.providers.fake_provider.GenericBackendV2).