### PR TITLE
updating docs notebook dependencies + use latest fakebackend

### DIFF
--- a/.github/workflows/kubernetes-deploy.yaml
+++ b/.github/workflows/kubernetes-deploy.yaml
@@ -61,7 +61,8 @@ jobs:
             matplotlib==3.7.1 \
             pyscf==2.2.1 \
             scipy==1.10 \
-            qiskit-aer>=0.13.1 \
+            qiskit-ibm-provider==0.9.0 \
+            qiskit-aer==0.13.1 \
             certifi==2023.7.22
           pip install nbmake pytest
       - name: Run notebooks

--- a/.github/workflows/kubernetes-deploy.yaml
+++ b/.github/workflows/kubernetes-deploy.yaml
@@ -56,13 +56,13 @@ jobs:
           cd client
           pip install . --no-cache-dir
           pip install --no-cache-dir \
-            ipywidgets==8.1.0 \
+            ipywidgets==8.1.1 \
             circuit-knitting-toolbox>=0.6.0 \
             matplotlib==3.7.1 \
             pyscf==2.2.1 \
             scipy==1.10 \
-            qiskit-ibm-provider==0.9.0 \
-            qiskit-aer==0.13.1 \
+            qiskit-ibm-provider>=0.9.0 \
+            qiskit-aer>=0.13.3 \
             certifi==2023.7.22
           pip install nbmake pytest
       - name: Run notebooks

--- a/.github/workflows/kubernetes-deploy.yaml
+++ b/.github/workflows/kubernetes-deploy.yaml
@@ -57,12 +57,11 @@ jobs:
           pip install . --no-cache-dir
           pip install --no-cache-dir \
             ipywidgets==8.1.0 \
-            circuit-knitting-toolbox==0.2.0 \
+            circuit-knitting-toolbox>=0.6.0 \
             matplotlib==3.7.1 \
             pyscf==2.2.1 \
             scipy==1.10 \
-            qiskit-ibmq-provider==0.20.2 \
-            qiskit-aer==0.12.0 \
+            qiskit-aer>=0.13.1 \
             certifi==2023.7.22
           pip install nbmake pytest
       - name: Run notebooks

--- a/client/quantum_serverless/core/provider.py
+++ b/client/quantum_serverless/core/provider.py
@@ -38,7 +38,7 @@ import ray
 import requests
 from ray.dashboard.modules.job.sdk import JobSubmissionClient
 from opentelemetry import trace
-from qiskit_ibm_runtime import QiskitRuntimeService
+from qiskit_ibm_provider import IBMProvider
 
 from quantum_serverless.core.constants import (
     REQUESTS_TIMEOUT,
@@ -534,7 +534,7 @@ class IBMServerlessProvider(ServerlessProvider):
             token: IBM quantum token
             name: Name of the account to load
         """
-        token = token or QiskitRuntimeService(name=name).active_account().get("token")
+        token = token or IBMProvider(name=name).active_account().get("token")
         super().__init__(token=token, host=IBM_SERVERLESS_HOST_URL)
 
     @staticmethod
@@ -551,7 +551,7 @@ class IBMServerlessProvider(ServerlessProvider):
             name: Name of the account to save
             overwrite: ``True`` if the existing account is to be overwritten
         """
-        QiskitRuntimeService.save_account(token=token, name=name, overwrite=overwrite)
+        IBMProvider.save_account(token=token, name=name, overwrite=overwrite)
 
     def get_compute_resources(self) -> List[ComputeResource]:
         raise NotImplementedError("GatewayProvider does not support resources api yet.")

--- a/client/quantum_serverless/core/provider.py
+++ b/client/quantum_serverless/core/provider.py
@@ -38,7 +38,7 @@ import ray
 import requests
 from ray.dashboard.modules.job.sdk import JobSubmissionClient
 from opentelemetry import trace
-from qiskit_ibm_provider import IBMProvider
+from qiskit_ibm_runtime import QiskitRuntimeService
 
 from quantum_serverless.core.constants import (
     REQUESTS_TIMEOUT,
@@ -534,7 +534,7 @@ class IBMServerlessProvider(ServerlessProvider):
             token: IBM quantum token
             name: Name of the account to load
         """
-        token = token or IBMProvider(name=name).active_account().get("token")
+        token = token or QiskitRuntimeService(name=name).active_account().get("token")
         super().__init__(token=token, host=IBM_SERVERLESS_HOST_URL)
 
     @staticmethod
@@ -551,7 +551,7 @@ class IBMServerlessProvider(ServerlessProvider):
             name: Name of the account to save
             overwrite: ``True`` if the existing account is to be overwritten
         """
-        IBMProvider.save_account(token=token, name=name, overwrite=overwrite)
+        QiskitRuntimeService.save_account(token=token, name=name, overwrite=overwrite)
 
     def get_compute_resources(self) -> List[ComputeResource]:
         raise NotImplementedError("GatewayProvider does not support resources api yet.")

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -4,8 +4,6 @@ importlib-metadata>=5.2.0
 qiskit>=0.45.2
 qiskit-ibm-runtime>=0.19.1
 qiskit-ibm-provider>=0.9.0
-# Forbid qiskit-terra from individual install with impossible version constraint.
-# qiskit-terra>=1
 # TODO: make sure ray node and notebook node have the same version of cloudpickle
 cloudpickle==2.2.1
 tqdm>=4.65.0

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -3,7 +3,6 @@ requests>=2.31.0
 importlib-metadata>=5.2.0
 qiskit>=0.45.2
 qiskit-ibm-runtime>=0.18.0
-qiskit-ibm-provider>=0.8.0
 # TODO: make sure ray node and notebook node have the same version of cloudpickle
 cloudpickle==2.2.1
 tqdm>=4.65.0

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -3,6 +3,7 @@ requests>=2.31.0
 importlib-metadata>=5.2.0
 qiskit>=0.45.2
 qiskit-ibm-runtime>=0.18.0
+qiskit-ibm-provider>=0.9.0
 # TODO: make sure ray node and notebook node have the same version of cloudpickle
 cloudpickle==2.2.1
 tqdm>=4.65.0

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -2,8 +2,10 @@ ray[default,data]>=2.9.1, <3
 requests>=2.31.0
 importlib-metadata>=5.2.0
 qiskit>=0.45.2
-qiskit-ibm-runtime>=0.18.0
+qiskit-ibm-runtime>=0.19.1
 qiskit-ibm-provider>=0.9.0
+# Forbid qiskit-terra from individual install with impossible version constraint.
+# qiskit-terra>=1
 # TODO: make sure ray node and notebook node have the same version of cloudpickle
 cloudpickle==2.2.1
 tqdm>=4.65.0

--- a/client/tests/library/test_transpiler.py
+++ b/client/tests/library/test_transpiler.py
@@ -31,8 +31,8 @@ class TestParallelTranspile(TestCase):
         circuit1 = random_circuit(5, 3)
         circuit2 = random_circuit(5, 3)
 
-        backend1 = GenericBackendV2()
-        backend2 = GenericBackendV2()
+        backend1 = GenericBackendV2(num_qubits=5)
+        backend2 = GenericBackendV2(num_qubits=5)
 
         with QuantumServerless().context():
             transpiled_circuits = parallel_transpile(
@@ -48,8 +48,8 @@ class TestParallelTranspile(TestCase):
         """Test failing cases for parallel transpile."""
         circuit1 = random_circuit(5, 3)
 
-        backend1 = GenericBackendV2()
-        backend2 = GenericBackendV2()
+        backend1 = GenericBackendV2(num_qubits=5)
+        backend2 = GenericBackendV2(num_qubits=5)
 
         with QuantumServerless().context():
             # inconsistent number of circuits and backends

--- a/client/tests/library/test_transpiler.py
+++ b/client/tests/library/test_transpiler.py
@@ -15,7 +15,7 @@ from unittest import TestCase
 
 from qiskit import QuantumCircuit
 from qiskit.circuit.random import random_circuit
-from qiskit.providers.fake_provider import GenericBackendV2, GenericBackendV2
+from qiskit.providers.fake_provider import GenericBackendV2
 
 from quantum_serverless import QuantumServerless
 from quantum_serverless.exception import QuantumServerlessException

--- a/client/tests/library/test_transpiler.py
+++ b/client/tests/library/test_transpiler.py
@@ -15,7 +15,7 @@ from unittest import TestCase
 
 from qiskit import QuantumCircuit
 from qiskit.circuit.random import random_circuit
-from qiskit.providers.fake_provider import FakeAlmadenV2, FakeBrooklynV2
+from qiskit.providers.fake_provider import GenericBackendV2, GenericBackendV2
 
 from quantum_serverless import QuantumServerless
 from quantum_serverless.exception import QuantumServerlessException
@@ -31,8 +31,8 @@ class TestParallelTranspile(TestCase):
         circuit1 = random_circuit(5, 3)
         circuit2 = random_circuit(5, 3)
 
-        backend1 = FakeAlmadenV2()
-        backend2 = FakeBrooklynV2()
+        backend1 = GenericBackendV2()
+        backend2 = GenericBackendV2()
 
         with QuantumServerless().context():
             transpiled_circuits = parallel_transpile(
@@ -48,8 +48,8 @@ class TestParallelTranspile(TestCase):
         """Test failing cases for parallel transpile."""
         circuit1 = random_circuit(5, 3)
 
-        backend1 = FakeAlmadenV2()
-        backend2 = FakeBrooklynV2()
+        backend1 = GenericBackendV2()
+        backend2 = GenericBackendV2()
 
         with QuantumServerless().context():
             # inconsistent number of circuits and backends

--- a/docs/getting_started/basic/03_dependencies.ipynb
+++ b/docs/getting_started/basic/03_dependencies.ipynb
@@ -76,7 +76,7 @@
     "    title=\"pattern-with-dependencies\",\n",
     "    entrypoint=\"pattern_with_dependencies.py\",\n",
     "    working_dir=\"./source_files/\",\n",
-    "    dependencies=[\"qiskit-experiments==0.5.2\"],\n",
+    "    dependencies=[\"qiskit-experiments==0.6.0\"],\n",
     ")"
    ]
   },


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Closes #1224 

Making the PR checks stages **Test QS on Kubernetes**, **Notebook LocalProvider tests** and **Client verify process**  Qiskit 1.0.0 compatible by updating the dependencies for this stage:
* omitting deprecated `qiskit-ibmq-provider` dependency
* updating `qiskit-aer`, `circuit-knitting-toolbox` to latest versions

Using GenericBackendV2 as fake backend as it is  Qiskit 1.0.0 compatible, see [here](https://docs.quantum.ibm.com/api/qiskit/providers_fake_provider).


### Details and comments

See failed tests in PR #1205 
