### PR TITLE
tag source of primitives as quantum-serverless

### DIFF
--- a/charts/quantum-serverless/charts/gateway/templates/rayclustertemplate.yaml
+++ b/charts/quantum-serverless/charts/gateway/templates/rayclustertemplate.yaml
@@ -13,10 +13,10 @@ data:
       labels:
         nodelete: "true"
 {{- end }}
-      annotations: 
+      annotations:
         user: {{`{{ user }}`}}
     spec:
-{{- if .Values.application.ray.scrapeWithPrometheus }}      
+{{- if .Values.application.ray.scrapeWithPrometheus }}
       headServiceAnnotations:
         prometheus.io/scrape: "true"
 {{- end }}
@@ -29,11 +29,11 @@ data:
 {{- end }}
         serviceType: ClusterIP
         template:
-{{- if .Values.application.ray.scrapeWithPrometheus }}                
+{{- if .Values.application.ray.scrapeWithPrometheus }}
           metadata:
             annotations:
               prometheus.io/scrape: "true"
-{{- end }}              
+{{- end }}
           spec:
             initContainers:
               # Generate head's private key and certificate before `ray start`.
@@ -112,6 +112,10 @@ data:
                 # See https://docs.ray.io/en/latest/ray-core/configure.html#tls-authentication for more details.
                 - name: RAY_USE_TLS
                   value: "1"
+                - name: CUSTOM_HEADER_ENV_VAR
+                  value: "QUANTUM_SERVERLESS_CLIENT_APP_HEADER"
+                - name: QE_PROVIDER_HEADER_ENV_VAR
+                  value: "QUANTUM_SERVERLESS_CLIENT_APP_HEADER"
 {{- if .Values.useCertManager }}
                 - name: RAY_TLS_SERVER_CERT
                   value: "/tmp/tls/tls.crt"
@@ -202,11 +206,11 @@ data:
           block: 'true'
         replicas: {{`{{ workers }}`}}
         template:
-{{- if .Values.application.ray.scrapeWithPrometheus }}      
+{{- if .Values.application.ray.scrapeWithPrometheus }}
           metadata:
             annotations:
               prometheus.io/scrape: "true"
-{{- end }}              
+{{- end }}
           spec:
             initContainers:
               # Generate worker's private key and certificate before `ray start`.
@@ -273,6 +277,10 @@ data:
                 # See https://docs.ray.io/en/latest/ray-core/configure.html#tls-authentication for more details.
                 - name: RAY_USE_TLS
                   value: "1"
+                - name: CUSTOM_HEADER_ENV_VAR
+                  value: "QUANTUM_SERVERLESS_CLIENT_APP_HEADER"
+                - name: QE_PROVIDER_HEADER_ENV_VAR
+                  value: "QUANTUM_SERVERLESS_CLIENT_APP_HEADER"
 {{- if .Values.useCertManager }}
                 - name: RAY_TLS_SERVER_CERT
                   value: "/tmp/tls/tls.crt"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #1127 


### Details and comments

Adds the environmental variables `CUSTOM_HEADER_ENV_VAR` and `QE_PROVIDER_HEADER_ENV_VAR`  to the Ray head/worker pods, each of which has the value `QUANTUM_SERVERLESS_CLIENT_APP_HEADER`.