### PR TITLE
Fix ExistingProgram serializer

### DIFF
--- a/gateway/api/serializers.py
+++ b/gateway/api/serializers.py
@@ -71,7 +71,7 @@ class ExistingProgramSerializer(serializers.Serializer):
     """Serializer for launching existing program."""
 
     title = serializers.CharField(max_length=255)
-    arguments = serializers.JSONField()
+    arguments = serializers.CharField()
 
     def update(self, instance, validated_data):
         pass

--- a/gateway/api/services.py
+++ b/gateway/api/services.py
@@ -145,7 +145,7 @@ class JobService:
     @staticmethod
     def save(
         program: Program,
-        arguments,
+        arguments: str,
         author,
         jobconfig: JobConfig,
         token: str,
@@ -175,7 +175,7 @@ class JobService:
             status=status,
             config=jobconfig,
         )
-        env = encrypt_env_vars(build_env_variables(token, job, json.dumps(arguments)))
+        env = encrypt_env_vars(build_env_variables(token, job, arguments))
         try:
             env["traceparent"] = carrier["traceparent"]
         except KeyError:

--- a/gateway/tests/api/test_v1_program.py
+++ b/gateway/tests/api/test_v1_program.py
@@ -59,8 +59,8 @@ class TestProgramApi(APITestCase):
             data={
                 "title": "Program",
                 "entrypoint": "program.py",
-                "arguments": {},
-                "dependencies": [],
+                "arguments": "{}",
+                "dependencies": "[]",
                 "config": '{"workers": null, "min_workers": 1, "max_workers": 5, "auto_scaling": true}',
             },
             format="json",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix #1238 

End-points `run` and `run_existing` where using different serializers. One was converting the `arguments` into a JSON and the another one to `str`. This pull request unify those serializers.

Later iterations of the work that we are doing in #1240 will improve this logic.