### PR TITLE
Add security policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,16 +51,17 @@ There are tons of useful resources about Git [out there](https://try.github.io/)
 
 ## Opening issues
 
-You can [open 4 types of issues](https://github.com/Qiskit-Extensions/quantum-serverless/issues/new/choose):
+You can [open 3 types of issues](https://github.com/Qiskit-Extensions/quantum-serverless/issues/new/choose):
 
 * Bug reports: for reporting a misfunction. Provide steps to reproduce and expected behaviour.
 * Enhancement request: to suggest improvements to the current code.
 * Feature request: if you have a new use case or feature that we are not supporting.
-* Security vulnerability: in case you find a vulnerability in the project.
 
 Core contributors classify the tasks according to its nature and prioritize them
 from sprint to sprint. Types are not mutually exclusive and can change over time
 if needed.
+
+Security vulnerabilities must be privately reported by following our [Security Policy](SECURITY.md).
 
 
 ## Contributing code

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report vulnerabilities, you can privately report a potential security issue
+via the Github security vulnerabilities feature. This can be done here:
+
+https://github.com/Qiskit-Extensions/quantum-serverless/security/advisories
+
+Please do **not** open a public issue about a potential security vulnerability.
+
+You can find more details on the security vulnerability feature in [this Github guide](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).
+
+


### PR DESCRIPTION
### Summary
- Add security policy
- Update contribution doc

Closes #1213 

### Details and comments
May need admin to add doc in https://github.com/Qiskit-Extensions/quantum-serverless/security/policy - or it will be automatically detected after merge.

Question: Add information about supported versions of this project?

