### PR TITLE
Drop python 3.8 support

### DIFF
--- a/.github/workflows/docker-verify.yaml
+++ b/.github/workflows/docker-verify.yaml
@@ -53,7 +53,6 @@ jobs:
         image:
           [
             "quantum-serverless-gateway:latest",
-            "quantum-serverless-ray-node:latest-py38",
             "quantum-serverless-ray-node:latest-py39",
             "quantum-serverless-ray-node:latest-py310",
           ]
@@ -61,9 +60,6 @@ jobs:
           - image: "quantum-serverless-gateway:latest"
             dockerfile: "./gateway/Dockerfile"
             pyversion: "3.9"
-          - image: "quantum-serverless-ray-node:latest-py38"
-            dockerfile: "Dockerfile-ray-node"
-            pyversion: "py38"
           - image: "quantum-serverless-ray-node:latest-py39"
             dockerfile: "Dockerfile-ray-node"
             pyversion: "py39"

--- a/.github/workflows/gateway-verify.yaml
+++ b/.github/workflows/gateway-verify.yaml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false # keep running if one leg fails
       matrix:
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
 

--- a/.github/workflows/icr-image-build-and-push.yaml
+++ b/.github/workflows/icr-image-build-and-push.yaml
@@ -16,10 +16,6 @@ jobs:
       matrix:
         include:
           - imagename: quantum-serverless-ray-node
-            pythonversion: py38
-            dockerfile: Dockerfile-ray-node
-            platforms: linux/amd64
-          - imagename: quantum-serverless-ray-node
             pythonversion: py39
             dockerfile: Dockerfile-ray-node
             platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release-pull-request.yaml
+++ b/.github/workflows/release-pull-request.yaml
@@ -12,7 +12,6 @@ jobs:
         image:
           [
             "quantum-serverless-gateway:latest",
-            "quantum-serverless-ray-node:latest-py38",
             "quantum-serverless-ray-node:latest-py39",
             "quantum-serverless-ray-node:latest-py310",
           ]
@@ -20,9 +19,6 @@ jobs:
           - image: "quantum-serverless-gateway:latest"
             dockerfile: "./gateway/Dockerfile"
             pyversion: "3.9"
-          - image: "quantum-serverless-ray-node:latest-py38"
-            dockerfile: "Dockerfile-ray-node"
-            pyversion: "py38"
           - image: "quantum-serverless-ray-node:latest-py39"
             dockerfile: "Dockerfile-ray-node"
             pyversion: "py39"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ else
 	arch="amd64"
 endif
 
-notebookImageName=$(repository)/quantum-serverless-notebook
 rayNodeImageName=$(repository)/quantum-serverless-ray-node
 gatewayImageName=$(repository)/quantum-serverless-gateway
 
@@ -20,23 +19,16 @@ gatewayImageName=$(repository)/quantum-serverless-gateway
 
 build-and-push: build-all push-all
 
-build-all: build-notebook build-ray-node build-gateway
-push-all: push-notebook push-ray-node push-gateway
-
-build-notebook:
-	docker build -t $(notebookImageName):$(version) -f Dockerfile-notebook .
+build-all: build-ray-node build-gateway
+push-all: push-ray-node push-gateway
 
 build-ray-node:
 	docker build -t $(rayNodeImageName):$(version) --build-arg TARGETARCH=$(arch) -f Dockerfile-ray-node .
 	docker build -t $(rayNodeImageName):$(version)-py310 --build-arg TARGETARCH=$(arch) --build-arg IMAGE_PY_VERSION=py310 -f Dockerfile-ray-node .
 	docker build -t $(rayNodeImageName):$(version)-py39  --build-arg TARGETARCH=$(arch) --build-arg IMAGE_PY_VERSION=py39  -f Dockerfile-ray-node .
-	docker build -t $(rayNodeImageName):$(version)-py38  --build-arg TARGETARCH=$(arch) --build-arg IMAGE_PY_VERSION=py38  -f Dockerfile-ray-node .
 
 build-gateway:
 	docker build -t $(gatewayImageName):$(version) -f ./gateway/Dockerfile .
-
-push-notebook:
-	docker push $(notebookImageName):$(version)
 
 push-ray-node:
 	docker push $(rayNodeImageName):$(version)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Stability](https://img.shields.io/badge/stability-alpha-f4d03f.svg)](https://github.com/Qiskit-Extensions/quantum-serverless/releases)
 [![License](https://img.shields.io/github/license/qiskit-community/quantum-prototype-template?label=License)](https://github.com/qiskit-community/quantum-prototype-template/blob/main/LICENSE.txt)
 [![Code style: Black](https://img.shields.io/badge/Code%20style-Black-000.svg)](https://github.com/psf/black)
-[![Python](https://img.shields.io/badge/Python-3.8%20%7C%203.9%20%7C%203.10-informational)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/Python-3.9%20%7C%203.10-informational)](https://www.python.org/)
 [![Qiskit](https://img.shields.io/badge/Qiskit-%E2%89%A5%201.0.0-6133BD)](https://github.com/Qiskit/qiskit)
 
 # Quantum serverless

--- a/charts/quantum-serverless/charts/gateway/templates/deployment.yaml
+++ b/charts/quantum-serverless/charts/gateway/templates/deployment.yaml
@@ -286,8 +286,6 @@ spec:
               value: {{ .Release.Namespace }}
             - name: RAY_NODE_IMAGE
               value: {{ .Values.application.ray.nodeImage | quote }}
-            - name: RAY_NODE_IMAGE_PY38
-              value: {{ .Values.application.ray.nodeImage_py38 | quote }}
             - name: RAY_NODE_IMAGE_PY39
               value: {{ .Values.application.ray.nodeImage_py39 | quote }}
             - name: RAY_NODE_IMAGE_PY310

--- a/charts/quantum-serverless/charts/gateway/values.yaml
+++ b/charts/quantum-serverless/charts/gateway/values.yaml
@@ -12,13 +12,12 @@ application:
   rayHost: "http://ray:8265/"
   auth:
     mechanism: mock_token
-    token: 
+    token:
       mock: awesome_token
   superuser:
     enable: true
   ray:
     nodeImage: "icr.io/quantum-public/quantum-serverless-ray-node:0.9.0-py39"
-    nodeImage_py38: "icr.io/quantum-public/quantum-serverless-ray-node:0.9.0-py38"
     nodeImage_py39: "icr.io/quantum-public/quantum-serverless-ray-node:0.9.0-py39"
     nodeImage_py310: "icr.io/quantum-public/quantum-serverless-ray-node:0.9.0-py310"
     cpu: 2
@@ -104,7 +103,7 @@ podAnnotations:
   prometheus.io/scrape: "true"
 
 
-podSecurityContext: 
+podSecurityContext:
   fsGroup: 1000
   runAsUser: 1000
   runAsGroup: 100

--- a/client/quantum_serverless/core/job.py
+++ b/client/quantum_serverless/core/job.py
@@ -89,7 +89,6 @@ class Configuration:  # pylint: disable=too-many-instance-attributes
     max_workers: Optional[int] = None
     auto_scaling: Optional[bool] = False
     python_version: Optional[str] = ""
-    PYTHON_V3_8 = "py38"
     PYTHON_V3_9 = "py39"
     PYTHON_V3_10 = "py310"
 

--- a/client/tests/README.md
+++ b/client/tests/README.md
@@ -36,10 +36,10 @@ The command `tox -eblack` will reformat all files in the repository according to
 
 ## Test (py##) environments
 
-The `py##` environments are the main test environments.  tox defines one for each version of Python.  For instance, the following command will run the tests on Python 3.8, Python 3.9, and Python 3.10:
+The `py##` environments are the main test environments.  tox defines one for each version of Python.  For instance, the following command will run the tests on Python 3.9 and Python 3.10:
 
 ```sh
-$ tox -epy38,py39,py310
+$ tox -epy39,py310
 ```
 
 First, these environments execute all tests using [pytest], which supports its own simple style of tests, in addition to [unittest]-style tests and [doctests] located throughout the project's docstrings.

--- a/client/tox.ini
+++ b/client/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.1
-envlist = py37, py38, py39, py310, lint, coverage
+envlist = py39, py310, lint, coverage
 # CI: skip-next-line
 skipsdist = true
 # CI: skip-next-line

--- a/gateway/api/models.py
+++ b/gateway/api/models.py
@@ -32,11 +32,9 @@ class JobConfig(models.Model):
         null=True,
     )
 
-    PYTHON_V3_8 = "py38"
     PYTHON_V3_9 = "py39"
     PYTHON_V3_10 = "py310"
     PYTHON_VERSIONS = [
-        (PYTHON_V3_8, "Version 3.8"),
         (PYTHON_V3_9, "Version 3.9"),
         (PYTHON_V3_10, "Version 3.10"),
     ]

--- a/gateway/api/models.py
+++ b/gateway/api/models.py
@@ -32,9 +32,11 @@ class JobConfig(models.Model):
         null=True,
     )
 
+    PYTHON_V3_8 = "py38"
     PYTHON_V3_9 = "py39"
     PYTHON_V3_10 = "py310"
     PYTHON_VERSIONS = [
+        (PYTHON_V3_8, "Version 3.8"),
         (PYTHON_V3_9, "Version 3.9"),
         (PYTHON_V3_10, "Version 3.10"),
     ]

--- a/gateway/api/serializers.py
+++ b/gateway/api/serializers.py
@@ -71,7 +71,6 @@ class JobConfigSerializer(serializers.ModelSerializer):
     )
     python_version = serializers.ChoiceField(
         choices=(
-            ("py38", "Version 3.8"),
             ("py39", "Version 3.9"),
             ("py310", "Version 3.10"),
         ),

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -313,7 +313,6 @@ RAY_NODE_IMAGE = os.environ.get(
 )
 RAY_NODE_IMAGES_MAP = {
     "default": RAY_NODE_IMAGE,
-    "py38": os.environ.get("RAY_NODE_IMAGE_PY38", RAY_NODE_IMAGE),
     "py39": os.environ.get("RAY_NODE_IMAGE_PY39", RAY_NODE_IMAGE),
     "py310": os.environ.get("RAY_NODE_IMAGE_PY310", RAY_NODE_IMAGE),
 }

--- a/gateway/tox.ini
+++ b/gateway/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.1
-envlist = py38, py39, py310, lint, coverage
+envlist = py39, py310, lint, coverage
 # CI: skip-next-line
 skipsdist = true
 # CI: skip-next-line


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Part of #1251 
Remove Python 3.8 support from builds / client / gateway / etc.

### Details and comments

Did not update https://github.com/Qiskit-Extensions/quantum-serverless/blob/841db743ff3334fa95e277c53093e30bd0a441d7/gateway/api/migrations/0012_jobconfig_python_version.py#L19 as it may still be a valid option there for historical data

