### PR TITLE
Additional logging for auth errors on custom backends

### DIFF
--- a/gateway/api/authentication.py
+++ b/gateway/api/authentication.py
@@ -36,7 +36,7 @@ def safe_request(request: Callable) -> Optional[Dict[str, Any]]:
         except Exception as json_exception:  # pylint: disable=broad-exception-caught
             logger.error(json_exception)
     if response is not None and not response.ok:
-        logger.error(f"{response.status_code}: {response.text}")
+        logger.error("%d : %s", response.status_code, response.text)
 
     return result
 

--- a/gateway/api/authentication.py
+++ b/gateway/api/authentication.py
@@ -91,22 +91,20 @@ class CustomTokenBackend(authentication.BaseAuthentication):
                             user = User(username=user_id)
                             user.save()
                     elif user_id is None:
-                        logger.warning("No user id.")
-
+                        logger.warning("Problems authenticating: No user id.")
                     else:  # not verified
-                        logger.warning("User is not verified.")
+                        logger.warning("Problems authenticating: User is not verified.")
 
                 else:  # verification_data is None
-                    logger.warning("No verification data returned from request.")
+                    logger.warning("Problems authenticating: No verification data returned from request.")
 
             else:  # auth_data is None
-                logger.warning("No authorization data returned from auth url.")
+                logger.warning("Problems authenticating: No authorization data returned from auth url.")
 
         elif auth_header is None:
-            logger.warning("User did not provide authorization token.")
-
+            logger.warning("Problems authenticating: User did not provide authorization token.")
         else:  # auth_url is None
-            logger.warning("No auth url: something is broken in our settings.")
+            logger.warning("Problems authenticating: No auth url: something is broken in our settings.")
 
         return user, CustomToken(token.encode()) if token else None
 

--- a/gateway/api/authentication.py
+++ b/gateway/api/authentication.py
@@ -90,22 +90,22 @@ class CustomTokenBackend(authentication.BaseAuthentication):
                         except User.DoesNotExist:
                             user = User(username=user_id)
                             user.save()
-                    if user_id is None:
+                    elif user_id is None:
                         logger.warning("No user id.")
 
-                    if not verified:
+                    else:  # not verified
                         logger.warning("User is not verified.")
 
-                if verification_data is None:
+                else:  # verification_data is None
                     logger.warning("No verification data returned from request.")
 
-            if auth_data is None:
+            else:  # auth_data is None
                 logger.warning("No authorization data returned from auth url.")
 
-        if auth_header is None:
+        elif auth_header is None:
             logger.warning("User did not provide authorization token.")
 
-        if auth_url is None:
+        else:  # auth_url is None
             logger.warning("No auth url: something is broken in our settings.")
 
         return user, CustomToken(token.encode()) if token else None

--- a/gateway/api/authentication.py
+++ b/gateway/api/authentication.py
@@ -96,15 +96,23 @@ class CustomTokenBackend(authentication.BaseAuthentication):
                         logger.warning("Problems authenticating: User is not verified.")
 
                 else:  # verification_data is None
-                    logger.warning("Problems authenticating: No verification data returned from request.")
+                    logger.warning(
+                        "Problems authenticating: No verification data returned from request."
+                    )
 
             else:  # auth_data is None
-                logger.warning("Problems authenticating: No authorization data returned from auth url.")
+                logger.warning(
+                    "Problems authenticating: No authorization data returned from auth url."
+                )
 
         elif auth_header is None:
-            logger.warning("Problems authenticating: User did not provide authorization token.")
+            logger.warning(
+                "Problems authenticating: User did not provide authorization token."
+            )
         else:  # auth_url is None
-            logger.warning("Problems authenticating: No auth url: something is broken in our settings.")
+            logger.warning(
+                "Problems authenticating: No auth url: something is broken in our settings."
+            )
 
         return user, CustomToken(token.encode()) if token else None
 

--- a/gateway/api/authentication.py
+++ b/gateway/api/authentication.py
@@ -44,7 +44,7 @@ def safe_request(request: Callable) -> Optional[Dict[str, Any]]:
 class CustomTokenBackend(authentication.BaseAuthentication):
     """Custom token backend for authentication against 3rd party auth service."""
 
-    def authenticate(self, request):
+    def authenticate(self, request):  # pylint: disable=too-many-branches
         auth_url = settings.SETTINGS_TOKEN_AUTH_URL
         verification_url = settings.SETTINGS_TOKEN_AUTH_VERIFICATION_URL
         auth_header = request.META.get("HTTP_AUTHORIZATION")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #1263 

### Details and comments

Adds log messages for each condition that might fail in `CustomTokenBackend.authenticate()`. Also logs an error if a safe request comes back as not ok.

I opted for explicit `if` statements (rather than using `else` or `elif`) to try to make it clearer which error conditions were being checked (it was easy to miss which else lined up with which if when relying solely on whitespace...)

I don't have an easy way to test against a third-party auth service (like IQP) locally, so these may require some hand checking.

