### PR TITLE
Make storage class name helm variable

### DIFF
--- a/charts/quantum-serverless/templates/pvcs.yaml
+++ b/charts/quantum-serverless/templates/pvcs.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.cos.claimName }}
+  name: {{ .Values.claimName }}
 spec:
   storageClassName: standard 
   accessModes:
@@ -51,9 +51,9 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.cos.claimName }}
+  name: {{ .Values.claimName }}
 spec:
-  storageClassName: manual
+  storageClassName:  {{ .Values.storageClassName | quote }}
   accessModes:
     - ReadWriteMany
   resources:

--- a/charts/quantum-serverless/templates/pvcs.yaml
+++ b/charts/quantum-serverless/templates/pvcs.yaml
@@ -14,7 +14,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.cos.claimName }}
+  name: {{ .Values.claimName }}
   annotations:
     ibm.io/auto-create-bucket: "false"
     ibm.io/auto-delete-bucket: "false"
@@ -29,7 +29,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.cos.storageSize | quote }}
-  storageClassName: {{ .Values.cos.storageClassName | quote }}
+  storageClassName: {{ .Values.storageClassName | quote }}
 {{ else }}
 apiVersion: v1
 kind: PersistentVolume

--- a/charts/quantum-serverless/templates/pvcs.yaml
+++ b/charts/quantum-serverless/templates/pvcs.yaml
@@ -1,4 +1,4 @@
-{{ if and (eq .Values.platform "kind") (eq .Values.cosEnable false) }}
+{{ if eq .Values.platform "kind" }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -10,7 +10,7 @@ spec:
   resources:
     requests:
       storage: 1Gi
-{{ else if and (eq .Values.platform "ibm") .Values.cosEnable }}
+{{ else if eq .Values.platform "ibm" }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/quantum-serverless/values.yaml
+++ b/charts/quantum-serverless/values.yaml
@@ -3,8 +3,6 @@
 # ===================
 platform: default
 
-storageClassName: manual
-claimName: gateway-claim
 # ===================
 # Ingress Nginx controller configs
 # ===================
@@ -124,14 +122,15 @@ postgresql:
     password: serverlesspassword
 
 # ===================
-# COS
+# PVC
 # ===================
+
+storageClassName: manual
+claimName: gateway-claim
 
 cosEnable: false
 cos:
   bucket: BUCKETNAME-CHANGEME
-  claimName: gateway-claim
   endpoint: ENDPOINT-CHANGEME
   secretName: SECRETNAME-CHANGEME
-  storageClassName: STORAGECLASSNAME-CHANGEME
   storageSize: 10Gi

--- a/charts/quantum-serverless/values.yaml
+++ b/charts/quantum-serverless/values.yaml
@@ -128,7 +128,6 @@ postgresql:
 storageClassName: manual
 claimName: gateway-claim
 
-cosEnable: false
 cos:
   bucket: BUCKETNAME-CHANGEME
   endpoint: ENDPOINT-CHANGEME

--- a/charts/quantum-serverless/values.yaml
+++ b/charts/quantum-serverless/values.yaml
@@ -3,6 +3,8 @@
 # ===================
 platform: default
 
+storageClassName: manual
+claimName: gateway-claim
 # ===================
 # Ingress Nginx controller configs
 # ===================


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This is one option to resolve #1231

2 new helm variables are added at the top level
1. `storageClassName` -- default manual
2. `claimName` -- default: gateway-claim

### Details and comments

This allows quantum-serverless to use the custom persistent volume.
