### PR TITLE
add version api endpoint to gateway

### DIFF
--- a/.github/workflows/update-component-versions.yaml
+++ b/.github/workflows/update-component-versions.yaml
@@ -43,6 +43,7 @@ jobs:
           sed -i "s/tag: \"${OLDNUM}\"/tag: \"${NEWNUM}\"/" charts/quantum-serverless/values.yaml
           sed -i "s/tag: \"${OLDNUM}-py39\"/tag: \"${NEWNUM}-py39\"/" charts/quantum-serverless/values.yaml
           sed -i "s/ray-node:${OLDNUM}/ray-node:${NEWNUM}/" charts/quantum-serverless/values.yaml
+          sed -i "s/version: ${OLDNUM}/version: ${NEWNUM}/" charts/quantum-serverless/values.yaml
           cd charts/quantum-serverless
           helm dependency update
           cd -

--- a/charts/quantum-serverless/charts/gateway/templates/deployment.yaml
+++ b/charts/quantum-serverless/charts/gateway/templates/deployment.yaml
@@ -84,6 +84,8 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
+            - name: VERSION
+              value: {{ .Values.global.version | quote }}
             - name: DEBUG
               value: {{ .Values.application.debug | quote }}
             - name: DJANGO_SECRET_KEY

--- a/charts/quantum-serverless/values.yaml
+++ b/charts/quantum-serverless/values.yaml
@@ -1,4 +1,10 @@
 # ===================
+# Quantum Serverless Info
+# ===================
+global:
+  version: 0.9.0
+
+# ===================
 # Quantum Serverless configs
 # ===================
 platform: default

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -17,6 +17,7 @@ from datetime import timedelta
 from pathlib import Path
 from utils import sanitize_file_path
 
+RELEASE_VERSION = os.environ.get("VERSION", "UNKNOWN")
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/gateway/main/urls.py
+++ b/gateway/main/urls.py
@@ -22,6 +22,7 @@ from rest_framework import routers, permissions
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 import probes.views
+import version.views as version
 
 schema = get_schema_view(  # pylint: disable=invalid-name
     openapi.Info(
@@ -45,6 +46,7 @@ urlpatterns = [
     path("accounts/", include("allauth.urls")),
     path("readiness/", probes.views.readiness, name="readiness"),
     path("liveness/", probes.views.liveness, name="liveness"),
+    path("version/", version.version, name="version"),
     path("", include("django_prometheus.urls")),
     re_path(r"^api/v1/", include(("api.v1.urls", "api"), namespace="v1")),
     # docs

--- a/gateway/main/urls.py
+++ b/gateway/main/urls.py
@@ -22,7 +22,7 @@ from rest_framework import routers, permissions
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 import probes.views
-import version.views as version
+import version.views
 
 schema = get_schema_view(  # pylint: disable=invalid-name
     openapi.Info(
@@ -46,7 +46,7 @@ urlpatterns = [
     path("accounts/", include("allauth.urls")),
     path("readiness/", probes.views.readiness, name="readiness"),
     path("liveness/", probes.views.liveness, name="liveness"),
-    path("version/", version.version, name="version"),
+    path("version/", version.views.version, name="version"),
     path("", include("django_prometheus.urls")),
     re_path(r"^api/v1/", include(("api.v1.urls", "api"), namespace="v1")),
     # docs

--- a/gateway/tests/version/test_version.py
+++ b/gateway/tests/version/test_version.py
@@ -1,0 +1,14 @@
+"""Test version."""
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+
+class TestProbes(APITestCase):
+    """TestVersion."""
+
+    def test_version(self):
+        """Tests version."""
+        jobs_response = self.client.get(reverse("version"))
+        self.assertEqual(jobs_response.status_code, status.HTTP_200_OK)

--- a/gateway/version/views.py
+++ b/gateway/version/views.py
@@ -1,0 +1,10 @@
+from django.http import HttpResponse
+import json
+import os
+import requests
+import main.settings
+
+
+def version(request):
+    info = {"version": main.settings.RELEASE_VERSION}
+    return HttpResponse(json.dumps(info))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
fix #1277 

This PR adds `/version/` endpoint to the gateway.  It returns `{"version": "0.9.0"}` now.


### Details and comments

The version is defined as the global variable of the quantum-serverless helm chart.