### PR TITLE
Bump sqlparse verson

### DIFF
--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -16,3 +16,4 @@ opentelemetry-exporter-otlp>=1.19.0
 django-concurrency>=2.4
 drf-yasg>=1.21.7
 cryptography>=41.0.1
+sqlparse>=0.5.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Django uses an older version of sqlparse, and we need to bump to a newer one. 

### Details and comments

